### PR TITLE
Feat: 로그인 및 회원가입 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# claude  
+# claude
 .omc
 .claude
+
+# playwright
+.playwright-mcp/
+playwright-report/
+test-results/

--- a/components.json
+++ b/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/mocks/data/members.json
+++ b/mocks/data/members.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "1",
+    "email": "20211234@skhu.ac.kr",
+    "password": "password123!",
+    "nickname": "밥순이",
+    "department": "소프트웨어공학과",
+    "admissionYear": "2021",
+    "avatar": "🍚",
+    "bio": "빠르게 먹고 싶을 때 같이 먹어요! 대화도 좋아해요 😊",
+    "category": ["면류", "한식"]
+  }
+]

--- a/mocks/data/members.json
+++ b/mocks/data/members.json
@@ -5,7 +5,7 @@
     "password": "password123!",
     "nickname": "밥순이",
     "department": "소프트웨어공학과",
-    "admissionYear": "2021",
+    "admission_year": "2021",
     "avatar": "🍚",
     "bio": "빠르게 먹고 싶을 때 같이 먹어요! 대화도 좋아해요 😊",
     "category": ["면류", "한식"]

--- a/mocks/dev-server.ts
+++ b/mocks/dev-server.ts
@@ -6,14 +6,25 @@ import { handlers } from "./handlers";
 const app = express();
 const PORT = 9090;
 
-app.use(cors({ origin: /^http:\/\/localhost:\d+$/ }));
-app.use(express.json());
-app.use((req, _res, next) => {
-  console.log(`[MSW] ${req.method} ${req.path}`);
+app.use(cors({ origin: /^http:\/\/(localhost|127\.0\.0\.1):\d+$/ }));
+app.use((req, res, next) => {
+  const start = Date.now();
+  console.log(`[MSW Server] Incoming: ${req.method} ${req.originalUrl} from ${req.headers.origin}`);
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    console.log(`[MSW Server] Result: ${req.method} ${req.originalUrl} -> ${res.statusCode} (${duration}ms)`);
+  });
   next();
 });
 
+app.use(express.json());
 app.use(createMiddleware(...handlers));
+
+// Fallback for unhandled routes
+app.use((req, res) => {
+  console.log(`[MSW] 404 Not Found: ${req.method} ${req.path}`);
+  res.status(404).json({ message: `Mock handler not found for ${req.method} ${req.path}` });
+});
 
 app.listen(PORT, () => {
   console.log(`[MSW] Mock server running on http://localhost:${PORT}`);

--- a/mocks/dev-server.ts
+++ b/mocks/dev-server.ts
@@ -26,6 +26,8 @@ app.use((req, res) => {
   res.status(404).json({ message: `Mock handler not found for ${req.method} ${req.path}` });
 });
 
-app.listen(PORT, () => {
-  console.log(`[MSW] Mock server running on http://localhost:${PORT}`);
+const HOST = "127.0.0.1";
+
+app.listen(PORT, HOST, () => {
+  console.log(`[MSW] Mock server running on http://${HOST}:${PORT}`);
 });

--- a/mocks/factories/index.ts
+++ b/mocks/factories/index.ts
@@ -1,0 +1,5 @@
+export { createMember, createMembers } from "./member.factory";
+export type { MemberData } from "./member.factory";
+
+export { createPost, createPosts } from "./post.factory";
+export type { PostData } from "./post.factory";

--- a/mocks/factories/member.factory.ts
+++ b/mocks/factories/member.factory.ts
@@ -32,7 +32,7 @@ export interface MemberData {
   password: string;
   nickname: string;
   department: string;
-  admissionYear: string;
+  admission_year: string;
   avatar: string | null;
   bio: string;
   category: string[];
@@ -50,7 +50,7 @@ export function createMember(overrides?: Partial<MemberData>): MemberData {
     password: "test1234!",
     nickname: faker.helpers.arrayElement(NICKNAME_POOL),
     department: faker.helpers.arrayElement(DEPARTMENTS),
-    admissionYear: String(year),
+    admission_year: String(year),
     avatar: faker.helpers.arrayElement(AVATARS),
     bio: faker.helpers.arrayElement(BIOS),
     category: faker.helpers.arrayElements(FOOD_CATEGORIES, { min: 1, max: 3 }),

--- a/mocks/factories/member.factory.ts
+++ b/mocks/factories/member.factory.ts
@@ -1,0 +1,63 @@
+import { faker } from "@faker-js/faker";
+
+const DEPARTMENTS = [
+  "소프트웨어공학과", "컴퓨터공학과", "정보통신공학과",
+  "경영학과", "경제학과", "사회복지학과",
+  "영어학과", "기계공학과", "전자공학과", "간호학과",
+];
+
+const FOOD_CATEGORIES = ["면류", "한식", "일식", "양식", "중식", "분식"];
+
+const AVATARS = ["🍚", "🍜", "🍣", "🍕", "🥟", "🌯", "🍱", "🥘", "🍲", "🥗"];
+
+const NICKNAME_POOL = [
+  "밥순이", "밥돌이", "점심왕", "먹보킹", "맛집헌터",
+  "배고픈곰", "점심이", "저녁이", "국밥러버", "면순이",
+  "한식킹", "맛있어", "먹자고", "배부름", "냠냠이",
+];
+
+const BIOS = [
+  "빠르게 먹고 싶을 때 같이 먹어요!",
+  "대화하면서 먹는 거 좋아요 😊",
+  "조용히 식사해요",
+  "뭐든 잘 먹어요!",
+  "맛집 탐방 좋아해요",
+  "혼밥 탈출 원해요",
+  "밥 먹으면서 친해져요",
+];
+
+export interface MemberData {
+  id: string;
+  email: string;
+  password: string;
+  nickname: string;
+  department: string;
+  admissionYear: string;
+  avatar: string | null;
+  bio: string;
+  category: string[];
+}
+
+let _id = 100;
+
+export function createMember(overrides?: Partial<MemberData>): MemberData {
+  const year = faker.number.int({ min: 2018, max: 2026 });
+  const studentNum = `${year}${faker.number.int({ min: 1000, max: 9999 })}`;
+
+  return {
+    id: String(++_id),
+    email: `${studentNum}@skhu.ac.kr`,
+    password: "test1234!",
+    nickname: faker.helpers.arrayElement(NICKNAME_POOL),
+    department: faker.helpers.arrayElement(DEPARTMENTS),
+    admissionYear: String(year),
+    avatar: faker.helpers.arrayElement(AVATARS),
+    bio: faker.helpers.arrayElement(BIOS),
+    category: faker.helpers.arrayElements(FOOD_CATEGORIES, { min: 1, max: 3 }),
+    ...overrides,
+  };
+}
+
+export function createMembers(count: number, overrides?: Partial<MemberData>): MemberData[] {
+  return Array.from({ length: count }, () => createMember(overrides));
+}

--- a/mocks/factories/post.factory.ts
+++ b/mocks/factories/post.factory.ts
@@ -1,0 +1,75 @@
+import { faker } from "@faker-js/faker";
+
+const FOOD_GROUPS = [
+  { category: "한식", thumbnail: "🍲", menus: ["부대찌개 + 공기밥", "김치찌개", "된장찌개", "비빔밥", "순두부찌개"] },
+  { category: "면류", thumbnail: "🍜", menus: ["짜장면", "짬뽕", "칼국수", "냉면", "라볶이"] },
+  { category: "일식", thumbnail: "🍣", menus: ["스시로 런치세트", "돈카츠 정식", "우동", "규동", "텐동"] },
+  { category: "양식", thumbnail: "🍕", menus: ["파스타", "피자", "버거 세트", "리조또", "샌드위치"] },
+  { category: "분식", thumbnail: "🌯", menus: ["떡볶이 세트", "김밥", "순대국", "튀김 정식", "라면"] },
+  { category: "중식", thumbnail: "🥟", menus: ["마라탕", "짜장면", "탕수육", "마파두부", "볶음밥"] },
+];
+
+const LOCATIONS = [
+  "학생회관 1층", "학생회관 2층", "정문 앞 골목",
+  "스타벅스 맞은편", "도서관 앞", "체육관 앞", "편의점 앞",
+];
+
+const MEMOS = [
+  "조용히 먹어요", "대화 환영!", "빠른 식사 선호해요",
+  "같이 걸어가요", "주문 미리 정해가요", "자리 맡아둘게요",
+];
+
+export interface PostData {
+  id: string;
+  host_id: string;
+  thumbnail: string;
+  category: string;
+  title: string;
+  location: string;
+  meeting_time: string;
+  max_participants: number;
+  current_participants: number;
+  status: "active" | "urgent" | "closed";
+  deadline: string;
+  memo?: string;
+  kakao_link?: string;
+}
+
+let _id = 100;
+
+export function createPost(overrides?: Partial<PostData>): PostData {
+  const group = faker.helpers.arrayElement(FOOD_GROUPS);
+  const maxParticipants = faker.number.int({ min: 2, max: 6 });
+  const currentParticipants = faker.number.int({ min: 1, max: maxParticipants });
+  const meetingTime = faker.date.soon({ days: 1 });
+  const deadline = new Date(meetingTime.getTime() - 30 * 60 * 1000);
+
+  const isClosed = currentParticipants >= maxParticipants;
+  const isUrgent = !isClosed && deadline.getTime() - Date.now() < 30 * 60 * 1000;
+  const status: PostData["status"] = isClosed ? "closed" : isUrgent ? "urgent" : "active";
+
+  return {
+    id: String(++_id),
+    host_id: String(faker.number.int({ min: 1, max: 10 })),
+    thumbnail: group.thumbnail,
+    category: group.category,
+    title: faker.helpers.arrayElement(group.menus),
+    location: faker.helpers.arrayElement(LOCATIONS),
+    meeting_time: meetingTime.toISOString(),
+    max_participants: maxParticipants,
+    current_participants: currentParticipants,
+    status,
+    deadline: deadline.toISOString(),
+    memo: faker.datatype.boolean(0.5)
+      ? faker.helpers.arrayElement(MEMOS)
+      : undefined,
+    kakao_link: faker.datatype.boolean(0.3)
+      ? `https://open.kakao.com/o/mock${_id}`
+      : undefined,
+    ...overrides,
+  };
+}
+
+export function createPosts(count: number, overrides?: Partial<PostData>): PostData[] {
+  return Array.from({ length: count }, () => createPost(overrides));
+}

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,3 +1,5 @@
-import { exampleHandlers } from "./handlers/example";
+import { memberHandlers } from "./handlers/member";
 
-export const handlers = [...exampleHandlers];
+export const handlers = [
+  ...memberHandlers
+];

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -1,0 +1,103 @@
+import { http, HttpResponse } from "msw";
+import membersData from "../data/members.json";
+import { createMembers } from "../factories/member.factory";
+import { User } from "@/types/auth";
+
+interface Member extends User {
+  password: string;
+}
+
+interface LoginBody { email: string; password: string }
+interface SendCodeBody { email: string }
+interface VerifyCodeBody { email: string; code: string }
+interface CheckNicknameBody { nickname: string }
+interface RegisterBody {
+  email: string; password: string; nickname: string;
+  department: string; admissionYear: string;
+  bio?: string; category?: string[];
+}
+
+const members: Member[] = [
+  ...membersData.map(m => ({
+    ...m,
+    avatar: m.avatar || null
+  })),
+  ...createMembers(10)
+];
+
+const pendingCodes = new Map<string, string>();
+
+const sanitizeUser = (user: Member): User => {
+  const { password, ...safeUser } = user;
+  return safeUser;
+};
+
+export const memberHandlers = [
+  http.post("/api/auth/login", async ({ request }) => {
+    const { email, password } = (await request.json()) as LoginBody;
+    const user = members.find(
+      (m) => m.email === email && m.password === password,
+    );
+
+    if (user) {
+      return HttpResponse.json({
+        message: "Login successful",
+        user: sanitizeUser(user),
+        token: `mock-jwt-token-${Math.random().toString(36).substr(2, 9)}`,
+      });
+    }
+    return new HttpResponse(JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" }
+    });
+  }),
+
+  http.post("/api/auth/send-code", async ({ request }) => {
+    const { email } = (await request.json()) as SendCodeBody;
+    if (!email.endsWith("@skhu.ac.kr")) {
+      return HttpResponse.json({ message: "학교 이메일만 사용 가능해요" }, { status: 400 });
+    }
+    pendingCodes.set(email, "123456");
+    return HttpResponse.json({ message: "인증코드가 발송됐어요" });
+  }),
+
+  http.post("/api/auth/verify-code", async ({ request }) => {
+    const { email, code } = (await request.json()) as VerifyCodeBody;
+    if (pendingCodes.get(email) === code) {
+      pendingCodes.delete(email);
+      return HttpResponse.json({ verified: true });
+    }
+    return HttpResponse.json({ message: "인증코드가 올바르지 않아요" }, { status: 400 });
+  }),
+
+  http.post("/api/auth/check-nickname", async ({ request }) => {
+    const { nickname } = (await request.json()) as CheckNicknameBody;
+    const taken = members.some((m) => m.nickname === nickname);
+    if (taken) {
+      return HttpResponse.json({ message: "이미 사용 중인 닉네임이에요" }, { status: 409 });
+    }
+    return HttpResponse.json({ available: true });
+  }),
+
+  http.post("/api/auth/register", async ({ request }) => {
+    const body = (await request.json()) as RegisterBody;
+    const newUser: Member = {
+      id: String(members.length + 101),
+      ...body,
+      avatar: null
+    };
+    members.push(newUser);
+    return HttpResponse.json(
+      {
+        message: "회원가입이 완료됐어요",
+        user: sanitizeUser(newUser),
+        token: "mock-jwt-token-new-user"
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.get("/api/members/me", () => {
+    return HttpResponse.json(sanitizeUser(members[0]));
+  }),
+];

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -13,7 +13,7 @@ interface VerifyCodeBody { email: string; code: string }
 interface CheckNicknameBody { nickname: string }
 interface RegisterBody {
   email: string; password: string; nickname: string;
-  department: string; admissionYear: string;
+  department: string; admission_year: string;
   bio?: string; category?: string[];
 }
 
@@ -26,6 +26,7 @@ const members: Member[] = [
 ];
 
 const pendingCodes = new Map<string, string>();
+const activeSessions = new Map<string, string>(); // token → email
 
 const sanitizeUser = (user: Member): User => {
   const { password, ...safeUser } = user;
@@ -40,10 +41,12 @@ export const memberHandlers = [
     );
 
     if (user) {
+      const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
+      activeSessions.set(token, user.email);
       return HttpResponse.json({
         message: "Login successful",
         user: sanitizeUser(user),
-        token: `mock-jwt-token-${Math.random().toString(36).substr(2, 9)}`,
+        token,
       });
     }
     return new HttpResponse(JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }), {
@@ -83,21 +86,34 @@ export const memberHandlers = [
     const body = (await request.json()) as RegisterBody;
     const newUser: Member = {
       id: String(members.length + 101),
-      ...body,
-      avatar: null
+      email: body.email,
+      password: body.password,
+      nickname: body.nickname,
+      department: body.department,
+      admissionYear: body.admission_year,
+      avatar: null,
+      bio: body.bio,
+      category: body.category,
     };
     members.push(newUser);
+    const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
+    activeSessions.set(token, newUser.email);
     return HttpResponse.json(
       {
         message: "회원가입이 완료됐어요",
         user: sanitizeUser(newUser),
-        token: "mock-jwt-token-new-user"
+        token,
       },
       { status: 201 },
     );
   }),
 
-  http.get("/api/members/me", () => {
-    return HttpResponse.json(sanitizeUser(members[0]));
+  http.get("/api/members/me", ({ request }) => {
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.replace("Bearer ", "");
+    const email = token ? activeSessions.get(token) : undefined;
+    const user = email ? members.find((m) => m.email === email) : members[0];
+    if (!user) return new HttpResponse(null, { status: 401 });
+    return HttpResponse.json(sanitizeUser(user));
   }),
 ];

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -137,7 +137,7 @@ export const memberHandlers = [
     const authHeader = request.headers.get("Authorization");
     const token = authHeader?.replace("Bearer ", "");
     const email = token ? activeSessions.get(token) : undefined;
-    const user = email ? members.find((m) => m.email === email) : members[0];
+    const user = email ? members.find((m) => m.email === email) : undefined;
     if (!user) return new HttpResponse(null, { status: 401 });
     return HttpResponse.json(sanitizeUser(user));
   }),

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -34,28 +34,45 @@ const sanitizeUser = (user: Member): User => {
 };
 
 export const memberHandlers = [
-  http.post("/api/auth/login", async ({ request }) => {
-    const { email, password } = (await request.json()) as LoginBody;
-    const user = members.find(
-      (m) => m.email === email && m.password === password,
-    );
+  // Auth: Login
+  http.post(/\/auth\/login$/, async ({ request }) => {
+    console.log(`[MSW Handler] Intercepted POST /api/auth/login`);
+    try {
+      const body = await request.json() as LoginBody;
+      console.log(`[MSW Handler] Body:`, body);
 
-    if (user) {
-      const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
-      activeSessions.set(token, user.email);
-      return HttpResponse.json({
-        message: "Login successful",
-        user: sanitizeUser(user),
-        token,
+      const { email, password } = body;
+      const user = members.find(
+        (m) => m.email === email && m.password === password,
+      );
+
+      if (user) {
+        console.log(`[MSW Handler] Login success for ${email}`);
+        const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
+        activeSessions.set(token, user.email);
+        return HttpResponse.json({
+          message: "Login successful",
+          user: sanitizeUser(user),
+          token,
+        });
+      }
+      console.log(`[MSW Handler] Login failed for ${email}`);
+      return new HttpResponse(JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" }
+      });
+    } catch (err) {
+      console.error(`[MSW Handler] Error parsing login body:`, err);
+      return new HttpResponse(JSON.stringify({ message: "Invalid request body" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
       });
     }
-    return new HttpResponse(JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }), {
-      status: 401,
-      headers: { "Content-Type": "application/json" }
-    });
   }),
 
-  http.post("/api/auth/send-code", async ({ request }) => {
+  // Auth: Send Code
+  http.post(/\/auth\/send-code$/, async ({ request }) => {
+    console.log(`[MSW Handler] Intercepted POST /api/auth/send-code`);
     const { email } = (await request.json()) as SendCodeBody;
     if (!email.endsWith("@skhu.ac.kr")) {
       return HttpResponse.json({ message: "학교 이메일만 사용 가능해요" }, { status: 400 });
@@ -64,7 +81,9 @@ export const memberHandlers = [
     return HttpResponse.json({ message: "인증코드가 발송됐어요" });
   }),
 
-  http.post("/api/auth/verify-code", async ({ request }) => {
+  // Auth: Verify Code
+  http.post(/\/auth\/verify-code$/, async ({ request }) => {
+    console.log(`[MSW Handler] Intercepted POST /api/auth/verify-code`);
     const { email, code } = (await request.json()) as VerifyCodeBody;
     if (pendingCodes.get(email) === code) {
       pendingCodes.delete(email);
@@ -73,7 +92,9 @@ export const memberHandlers = [
     return HttpResponse.json({ message: "인증코드가 올바르지 않아요" }, { status: 400 });
   }),
 
-  http.post("/api/auth/check-nickname", async ({ request }) => {
+  // Auth: Check Nickname
+  http.post(/\/auth\/check-nickname$/, async ({ request }) => {
+    console.log(`[MSW Handler] Intercepted POST /api/auth/check-nickname`);
     const { nickname } = (await request.json()) as CheckNicknameBody;
     const taken = members.some((m) => m.nickname === nickname);
     if (taken) {
@@ -82,7 +103,9 @@ export const memberHandlers = [
     return HttpResponse.json({ available: true });
   }),
 
-  http.post("/api/auth/register", async ({ request }) => {
+  // Auth: Register
+  http.post(/\/auth\/register$/, async ({ request }) => {
+    console.log(`[MSW Handler] Intercepted POST /api/auth/register`);
     const body = (await request.json()) as RegisterBody;
     const newUser: Member = {
       id: String(members.length + 101),
@@ -108,7 +131,9 @@ export const memberHandlers = [
     );
   }),
 
-  http.get("/api/members/me", ({ request }) => {
+  // Member: Get Me
+  http.get(/\/users\/me$/, ({ request }) => {
+    console.log(`[MSW Handler] Intercepted GET /api/members/me`);
     const authHeader = request.headers.get("Authorization");
     const token = authHeader?.replace("Bearer ", "");
     const email = token ? activeSessions.get(token) : undefined;

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -13,9 +13,10 @@ interface VerifyCodeBody { email: string; code: string }
 interface CheckNicknameBody { nickname: string }
 interface RegisterBody {
   email: string; password: string; nickname: string;
-  department: string; admissionYear: string;
+  department: string; admission_year: string;
   bio?: string; category?: string[];
 }
+interface RefreshBody { refresh_token: string }
 
 const members: Member[] = [
   ...membersData.map(m => ({
@@ -26,53 +27,53 @@ const members: Member[] = [
 ];
 
 const pendingCodes = new Map<string, string>();
-const activeSessions = new Map<string, string>(); // token → email
+const activeSessions = new Map<string, { email: string; type: "access" | "refresh" }>();
 
 const sanitizeUser = (user: Member): User => {
   const { password, ...safeUser } = user;
   return safeUser;
 };
 
+const makeTokens = (email: string) => {
+  const access_token = `mock-access-${Math.random().toString(36).slice(2, 11)}`;
+  const refresh_token = `mock-refresh-${Math.random().toString(36).slice(2, 11)}`;
+  activeSessions.set(access_token, { email, type: "access" });
+  activeSessions.set(refresh_token, { email, type: "refresh" });
+  return { access_token, refresh_token };
+};
+
 export const memberHandlers = [
   // Auth: Login
   http.post(/\/auth\/login$/, async ({ request }) => {
-    console.log(`[MSW Handler] Intercepted POST /api/auth/login`);
+    console.log(`[MSW Handler] Intercepted POST /auth/login`);
     try {
       const body = await request.json() as LoginBody;
-      console.log(`[MSW Handler] Body:`, body);
-
       const { email, password } = body;
-      const user = members.find(
-        (m) => m.email === email && m.password === password,
-      );
+      const user = members.find(m => m.email === email && m.password === password);
 
       if (user) {
-        console.log(`[MSW Handler] Login success for ${email}`);
-        const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
-        activeSessions.set(token, user.email);
+        const tokens = makeTokens(user.email);
         return HttpResponse.json({
           message: "Login successful",
           user: sanitizeUser(user),
-          token,
+          ...tokens,
         });
       }
-      console.log(`[MSW Handler] Login failed for ${email}`);
-      return new HttpResponse(JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new HttpResponse(
+        JSON.stringify({ message: "아이디 또는 비밀번호가 틀렸어요" }),
+        { status: 401, headers: { "Content-Type": "application/json" } }
+      );
     } catch (err) {
       console.error(`[MSW Handler] Error parsing login body:`, err);
-      return new HttpResponse(JSON.stringify({ message: "Invalid request body" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new HttpResponse(
+        JSON.stringify({ message: "Invalid request body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
     }
   }),
 
   // Auth: Send Code
   http.post(/\/auth\/send-code$/, async ({ request }) => {
-    console.log(`[MSW Handler] Intercepted POST /api/auth/send-code`);
     const { email } = (await request.json()) as SendCodeBody;
     if (!email.endsWith("@skhu.ac.kr")) {
       return HttpResponse.json({ message: "학교 이메일만 사용 가능해요" }, { status: 400 });
@@ -83,7 +84,6 @@ export const memberHandlers = [
 
   // Auth: Verify Code
   http.post(/\/auth\/verify-code$/, async ({ request }) => {
-    console.log(`[MSW Handler] Intercepted POST /api/auth/verify-code`);
     const { email, code } = (await request.json()) as VerifyCodeBody;
     if (pendingCodes.get(email) === code) {
       pendingCodes.delete(email);
@@ -92,52 +92,74 @@ export const memberHandlers = [
     return HttpResponse.json({ message: "인증코드가 올바르지 않아요" }, { status: 400 });
   }),
 
-  // Auth: Check Nickname
+  // Auth: Check Nickname — 스펙대로 항상 200, available: true/false
   http.post(/\/auth\/check-nickname$/, async ({ request }) => {
-    console.log(`[MSW Handler] Intercepted POST /api/auth/check-nickname`);
     const { nickname } = (await request.json()) as CheckNicknameBody;
-    const taken = members.some((m) => m.nickname === nickname);
-    if (taken) {
-      return HttpResponse.json({ message: "이미 사용 중인 닉네임이에요" }, { status: 409 });
-    }
-    return HttpResponse.json({ available: true });
+    const taken = members.some(m => m.nickname === nickname);
+    return HttpResponse.json({ available: !taken });
   }),
 
   // Auth: Register
   http.post(/\/auth\/register$/, async ({ request }) => {
-    console.log(`[MSW Handler] Intercepted POST /api/auth/register`);
     const body = (await request.json()) as RegisterBody;
+    const emailTaken = members.some(m => m.email === body.email);
+    if (emailTaken) {
+      return HttpResponse.json({ message: "이미 사용 중인 이메일이에요" }, { status: 409 });
+    }
+    const nicknameTaken = members.some(m => m.nickname === body.nickname);
+    if (nicknameTaken) {
+      return HttpResponse.json({ message: "이미 사용 중인 닉네임이에요" }, { status: 409 });
+    }
     const newUser: Member = {
       id: String(members.length + 101),
       email: body.email,
       password: body.password,
       nickname: body.nickname,
       department: body.department,
-      admissionYear: body.admissionYear,
+      admission_year: body.admission_year,
       avatar: null,
       bio: body.bio,
       category: body.category,
     };
     members.push(newUser);
-    const token = `mock-jwt-token-${Math.random().toString(36).slice(2, 11)}`;
-    activeSessions.set(token, newUser.email);
+    const { access_token } = makeTokens(newUser.email);
     return HttpResponse.json(
-      {
-        message: "회원가입이 완료됐어요",
-        user: sanitizeUser(newUser),
-        token,
-      },
+      { message: "회원가입이 완료됐어요", user: sanitizeUser(newUser), access_token },
       { status: 201 },
     );
   }),
 
+  // Auth: Refresh
+  http.post(/\/auth\/refresh$/, async ({ request }) => {
+    const body = (await request.json()) as RefreshBody;
+    const session = activeSessions.get(body.refresh_token);
+    if (!session || session.type !== "refresh") {
+      return HttpResponse.json({ message: "유효하지 않은 refresh_token이에요" }, { status: 401 });
+    }
+    // 기존 refresh token 무효화
+    activeSessions.delete(body.refresh_token);
+    const newAccess = `mock-access-${Math.random().toString(36).slice(2, 11)}`;
+    activeSessions.set(newAccess, { email: session.email, type: "access" });
+    return HttpResponse.json({ access_token: newAccess });
+  }),
+
+  // Auth: Logout
+  http.post(/\/auth\/logout$/, async ({ request }) => {
+    const body = (await request.json()) as RefreshBody;
+    const session = activeSessions.get(body.refresh_token);
+    if (session) activeSessions.delete(body.refresh_token);
+    return HttpResponse.json({ message: "로그아웃 됐어요" });
+  }),
+
   // Member: Get Me
   http.get(/\/users\/me$/, ({ request }) => {
-    console.log(`[MSW Handler] Intercepted GET /api/members/me`);
     const authHeader = request.headers.get("Authorization");
     const token = authHeader?.replace("Bearer ", "");
-    const email = token ? activeSessions.get(token) : undefined;
-    const user = email ? members.find((m) => m.email === email) : undefined;
+    const session = token ? activeSessions.get(token) : undefined;
+    if (!session || session.type !== "access") {
+      return new HttpResponse(null, { status: 401 });
+    }
+    const user = members.find(m => m.email === session.email);
     if (!user) return new HttpResponse(null, { status: 401 });
     return HttpResponse.json(sanitizeUser(user));
   }),

--- a/mocks/handlers/member.ts
+++ b/mocks/handlers/member.ts
@@ -13,7 +13,7 @@ interface VerifyCodeBody { email: string; code: string }
 interface CheckNicknameBody { nickname: string }
 interface RegisterBody {
   email: string; password: string; nickname: string;
-  department: string; admission_year: string;
+  department: string; admissionYear: string;
   bio?: string; category?: string[];
 }
 
@@ -113,7 +113,7 @@ export const memberHandlers = [
       password: body.password,
       nickname: body.nickname,
       department: body.department,
-      admissionYear: body.admission_year,
+      admissionYear: body.admissionYear,
       avatar: null,
       bio: body.bio,
       category: body.category,

--- a/package.json
+++ b/package.json
@@ -10,11 +10,24 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-slot": "^1.2.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.8.0",
     "next": "16.2.2",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-hook-form": "^7.74.0",
+    "shadcn": "^4.5.0",
+    "tailwind-merge": "^3.5.0",
+    "tw-animate-css": "^1.4.0",
+    "vaul": "^1.1.2",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "@mswjs/http-middleware": "^0.10.3",
     "@tailwindcss/postcss": "^4",
     "@types/cors": "^2.8.19",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.74.0",
+    "server-only": "^0.0.1",
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.4)
       next:
         specifier: 16.2.2
         version: 16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -17,7 +35,28 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.74.0
+        version: 7.74.0(react@19.2.4)
+      shadcn:
+        specifier: ^4.5.0
+        version: 4.5.0(@types/node@20.19.39)(typescript@5.9.3)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
       '@mswjs/http-middleware':
         specifier: ^0.10.3
         version: 0.10.3(msw@2.13.0(@types/node@20.19.39)(typescript@5.9.3))
@@ -89,12 +128,26 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -106,6 +159,24 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -128,6 +199,40 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -139,6 +244,43 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@dotenvx/dotenvx@1.63.0':
+    resolution: {integrity: sha512-jjkmzIRu19uH78AjFInqfcALehbDCZZ7M09hurVawyqNxtOXEg2LR73L59y4QnzfYDEzjbhVzGAd2uDHu0D1aQ==}
+    hasBin: true
+
+  '@ecies/ciphers@0.2.6':
+    resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -342,6 +484,31 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -563,6 +730,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@mswjs/http-middleware@0.10.3':
     resolution: {integrity: sha512-6CoX9IivDF7hggORdA4vX6uz+pkY1urGQMhmviHmYya/0b4EXwmhaXlGLQG3G29heqb3qdjp61V0+E2xRtyR5A==}
     engines: {node: '>=18'}
@@ -634,6 +811,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -659,8 +848,239 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -757,6 +1177,9 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -812,6 +1235,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/validate-npm-package-name@4.0.2':
+    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -993,12 +1419,31 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1006,6 +1451,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1048,6 +1497,10 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1101,6 +1554,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1128,6 +1585,21 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -1139,12 +1611,27 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1188,15 +1675,33 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1235,12 +1740,36 @@ packages:
       supports-color:
         optional: true
 
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -1258,19 +1787,37 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eciesjs@0.4.18:
+    resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1285,6 +1832,13 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -1438,6 +1992,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1458,6 +2017,28 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -1473,11 +2054,18 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1490,6 +2078,14 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1522,6 +2118,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1533,6 +2133,10 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1549,6 +2153,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -1561,13 +2168,33 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -1643,9 +2270,25 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1678,6 +2321,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -1685,6 +2332,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -1717,6 +2367,11 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1737,6 +2392,19 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -1756,12 +2424,24 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -1770,6 +2450,14 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -1783,6 +2471,14 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -1795,11 +2491,19 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -1808,6 +2512,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1824,8 +2531,17 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1839,12 +2555,23 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -1931,6 +2658,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1938,12 +2668,21 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1966,6 +2705,9 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1999,6 +2741,14 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2072,12 +2822,29 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2090,6 +2857,10 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object-treeify@1.1.33:
+    resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
+    engines: {node: '>= 10'}
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
@@ -2118,9 +2889,25 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -2141,9 +2928,20 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2152,6 +2950,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -2176,9 +2978,17 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2188,9 +2998,21 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -2231,12 +3053,52 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.74.0:
+    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2250,6 +3112,13 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2262,6 +3131,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
@@ -2272,6 +3145,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2340,6 +3217,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  shadcn@4.5.0:
+    resolution: {integrity: sha512-ZpNOz7IMI5aezbMEWNxBvl2aJ1ek6NuAMqpL/FUnk5IuRxERl8ohYEnqqAmhPOcur8RbGuCoqTZLQ3Oi4Xkf8A==}
+    hasBin: true
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2372,12 +3253,22 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   stable-hash@0.0.5:
@@ -2386,6 +3277,10 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2397,6 +3292,10 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2421,13 +3320,29 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-object@5.0.0:
+    resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
+    engines: {node: '>=14.16'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2462,12 +3377,18 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -2502,8 +3423,15 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2512,6 +3440,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2564,6 +3495,14 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2583,13 +3522,55 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2612,6 +3593,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -2626,6 +3612,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2646,9 +3636,22 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yocto-spinner@1.1.0:
+    resolution: {integrity: sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==}
+    engines: {node: '>=18.19'}
+
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -2656,8 +3659,29 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2699,6 +3723,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
@@ -2707,7 +3735,27 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -2725,6 +3773,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -2739,6 +3809,48 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -2762,6 +3874,46 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@dotenvx/dotenvx@1.63.0':
+    dependencies:
+      commander: 11.1.0
+      dotenv: 17.4.2
+      eciesjs: 0.4.18
+      execa: 5.1.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      ignore: 5.3.2
+      object-treeify: 1.1.33
+      picomatch: 4.0.4
+      which: 4.0.0
+      yocto-spinner: 1.1.0
+
+  '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
+    dependencies:
+      '@noble/ciphers': 1.3.0
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -2902,6 +4054,29 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@faker-js/faker@10.4.0': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
 
   '@humanfs/core@0.19.1': {}
 
@@ -3058,6 +4233,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@mswjs/http-middleware@0.10.3(msw@2.13.0(@types/node@20.19.39)(typescript@5.9.3))':
     dependencies:
       express: 4.22.1
@@ -3112,6 +4309,14 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.2':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3135,7 +4340,196 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@rtsao/scc@1.1.0': {}
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3210,6 +4604,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -3275,6 +4675,8 @@ snapshots:
       '@types/node': 20.19.39
 
   '@types/statuses@2.0.6': {}
+
+  '@types/validate-npm-package-name@4.0.2': {}
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3442,6 +4844,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3449,13 +4857,26 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -3530,6 +4951,10 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -3598,6 +5023,10 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3626,6 +5055,18 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -3636,11 +5077,19 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
+  code-block-writer@13.0.3: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@11.1.0: {}
+
+  commander@14.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -3676,15 +5125,28 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3716,13 +5178,26 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dedent@1.7.2: {}
+
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
 
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -3736,9 +5211,15 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
+  diff@8.0.4: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3746,9 +5227,18 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eciesjs@0.4.18:
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.331: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3760,6 +5250,12 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.1:
     dependencies:
@@ -4091,6 +5587,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -4104,6 +5602,44 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@4.22.1:
     dependencies:
@@ -4184,9 +5720,19 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -4195,6 +5741,15 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4243,11 +5798,21 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
+
+  fs-extra@11.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fsevents@2.3.3:
     optional: true
@@ -4265,11 +5830,15 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  fuzzysort@3.1.0: {}
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4284,10 +5853,21 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-nonce@1.0.1: {}
+
+  get-own-enumerable-keys@1.0.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -4352,6 +5932,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.15: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -4359,6 +5941,17 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@2.1.0: {}
+
+  human-signals@8.0.1: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4387,6 +5980,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -4394,6 +5989,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -4433,6 +6030,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -4453,6 +6052,14 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-interactive@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -4466,6 +6073,10 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -4475,11 +6086,17 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  is-regexp@3.1.0: {}
+
   is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -4496,6 +6113,10 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -4507,9 +6128,15 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -4522,6 +6149,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -4532,7 +6161,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4541,6 +6176,12 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -4552,6 +6193,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -4613,11 +6258,18 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lines-and-columns@1.2.4: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   loose-envify@1.4.0:
     dependencies:
@@ -4626,6 +6278,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.8.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:
@@ -4640,6 +6296,8 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -4663,6 +6321,10 @@ snapshots:
       mime-db: 1.54.0
 
   mime@1.6.0: {}
+
+  mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4739,6 +6401,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -4746,13 +6410,30 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.37: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
+
+  object-treeify@1.1.33: {}
 
   object.assign@4.1.7:
     dependencies:
@@ -4798,6 +6479,23 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4806,6 +6504,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   outvariant@1.4.3: {}
 
@@ -4827,11 +6537,24 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-ms@4.0.0: {}
+
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -4847,7 +6570,14 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pkce-challenge@5.0.1: {}
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.4.31:
     dependencies:
@@ -4861,7 +6591,18 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  powershell-utils@0.1.0: {}
+
   prelude-ls@1.2.1: {}
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -4907,9 +6648,48 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-hook-form@7.74.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.4: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4933,6 +6713,10 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4945,6 +6729,11 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   rettime@0.10.1: {}
 
@@ -4959,6 +6748,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -5073,6 +6864,49 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  shadcn@4.5.0(@types/node@20.19.39)(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@dotenvx/dotenvx': 1.63.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@types/validate-npm-package-name': 4.0.2
+      browserslist: 4.28.2
+      commander: 14.0.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      dedent: 1.7.2
+      deepmerge: 4.3.1
+      diff: 8.0.4
+      execa: 9.6.1
+      fast-glob: 3.3.3
+      fs-extra: 11.3.4
+      fuzzysort: 3.1.0
+      https-proxy-agent: 7.0.6
+      kleur: 4.1.5
+      msw: 2.13.0(@types/node@20.19.39)(typescript@5.9.3)
+      node-fetch: 3.3.2
+      open: 11.0.0
+      ora: 8.2.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
+      prompts: 2.4.2
+      recast: 0.23.11
+      stringify-object: 5.0.0
+      tailwind-merge: 3.5.0
+      ts-morph: 26.0.0
+      tsconfig-paths: 4.2.0
+      validate-npm-package-name: 7.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - typescript
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -5141,13 +6975,21 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
 
   stable-hash@0.0.5: {}
 
   statuses@2.0.2: {}
+
+  stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5161,6 +7003,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5212,11 +7060,25 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-object@5.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom@3.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -5239,9 +7101,13 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwind-merge@3.5.0: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -5270,10 +7136,21 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -5285,6 +7162,8 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -5360,6 +7239,10 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicorn-magic@0.3.0: {}
+
+  universalify@2.0.1: {}
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
@@ -5398,9 +7281,43 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  util-deprecate@1.0.2: {}
+
   utils-merge@1.0.1: {}
 
+  validate-npm-package-name@7.0.2: {}
+
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5447,6 +7364,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@6.2.0:
@@ -5462,6 +7383,11 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   y18n@5.0.8: {}
 
@@ -5481,10 +7407,28 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
+  yocto-spinner@1.1.0:
+    dependencies:
+      yoctocolors: 2.1.2
+
   yoctocolors-cjs@2.1.3: {}
+
+  yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
 
+  zod@3.25.76: {}
+
   zod@4.3.6: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-hook-form:
         specifier: ^7.74.0
         version: 7.74.0(react@19.2.4)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       shadcn:
         specifier: ^4.5.0
         version: 4.5.0(@types/node@20.19.39)(typescript@5.9.3)
@@ -3201,6 +3204,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6839,6 +6845,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PROTECTED = ["/", "/friends", "/create", "/chat", "/profile"];
+const PUBLIC_ONLY = ["/login", "/register"];
+
+export function proxy(req: NextRequest) {
+  const path = req.nextUrl.pathname;
+  const token = req.cookies.get("auth-token")?.value;
+
+  const isProtected = PROTECTED.some(
+    (r) => path === r || (r !== "/" && path.startsWith(r + "/"))
+  );
+  const isPublicOnly = PUBLIC_ONLY.some((r) => path.startsWith(r));
+
+  if (isProtected && !token) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  if (isPublicOnly && token) {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -18,6 +19,11 @@ interface LoginForm {
 export default function LoginPage() {
   const router = useRouter();
   const { setAuth, isAuthenticated, _hasHydrated } = useAuthStore();
+  const [ready, setReady] = useState(false);
+
+  useLayoutEffect(() => {
+    setReady(true);
+  }, []);
 
   const {
     register,
@@ -39,7 +45,7 @@ export default function LoginPage() {
     }
   });
 
-  if (!_hasHydrated) {
+  if (!ready || !_hasHydrated) {
     return <div className="flex flex-col flex-1 bg-white h-full" />;
   }
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useLayoutEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -19,11 +18,6 @@ interface LoginForm {
 export default function LoginPage() {
   const router = useRouter();
   const { setAuth, isAuthenticated, _hasHydrated } = useAuthStore();
-  const [ready, setReady] = useState(false);
-
-  useLayoutEffect(() => {
-    setReady(true);
-  }, []);
 
   const {
     register,
@@ -34,7 +28,9 @@ export default function LoginPage() {
 
   const onSubmit = handleSubmit(async ({ emailId, password }) => {
     try {
-      const fullEmail = emailId.includes("@") ? emailId : `${emailId}@skhu.ac.kr`;
+      const fullEmail = emailId.includes("@")
+        ? emailId
+        : `${emailId}@skhu.ac.kr`;
       const { user, token } = await authService.login(fullEmail, password);
       setAuth(user, token);
       router.replace("/");
@@ -45,7 +41,7 @@ export default function LoginPage() {
     }
   });
 
-  if (!ready || !_hasHydrated) {
+  if (!_hasHydrated) {
     return <div className="flex flex-col flex-1 bg-white h-full" />;
   }
 
@@ -58,13 +54,18 @@ export default function LoginPage() {
     <div className="flex flex-col flex-1 bg-white animate-fade-slide-up h-full">
       <TopBar
         showLogo
-        rightAction={<button className="text-[14px] font-medium text-grey-600 px-[10px] py-[6px]">도움말</button>}
+        rightAction={
+          <button className="text-[14px] font-medium text-grey-600 px-[10px] py-[6px]">
+            도움말
+          </button>
+        }
       />
 
       <main className="flex-1 overflow-y-auto px-6 py-7 flex flex-col no-scrollbar">
         <section className="mb-8">
           <h1 className="text-[26px] font-bold text-grey-900 leading-[36px] tracking-[-0.6px] mb-2">
-            오늘 점심,<br />
+            오늘 점심,
+            <br />
             <span className="hl">같이 먹을 친구</span>를<br />
             찾아보세요
           </h1>
@@ -109,7 +110,10 @@ export default function LoginPage() {
             <Input
               {...register("password", {
                 required: "비밀번호를 입력해주세요",
-                minLength: { value: 8, message: "비밀번호는 8자 이상이어야 해요" },
+                minLength: {
+                  value: 8,
+                  message: "비밀번호는 8자 이상이어야 해요",
+                },
               })}
               type="password"
               placeholder="비밀번호 입력"
@@ -138,17 +142,34 @@ export default function LoginPage() {
           </Button>
 
           <div className="flex items-center justify-center gap-0 mt-4">
-            <Link href="#" className="text-[13px] font-medium text-grey-600 px-[10px] py-1">아이디 찾기</Link>
+            <Link
+              href="#"
+              className="text-[13px] font-medium text-grey-600 px-[10px] py-1"
+            >
+              아이디 찾기
+            </Link>
             <span className="text-grey-300 text-[13px]">|</span>
-            <Link href="#" className="text-[13px] font-medium text-grey-600 px-[10px] py-1">비밀번호 재설정</Link>
+            <Link
+              href="#"
+              className="text-[13px] font-medium text-grey-600 px-[10px] py-1"
+            >
+              비밀번호 재설정
+            </Link>
             <span className="text-grey-300 text-[13px]">|</span>
-            <Link href="/signup" className="text-[13px] font-bold text-grey-900 px-[10px] py-1">회원가입</Link>
+            <Link
+              href="/signup"
+              className="text-[13px] font-bold text-grey-900 px-[10px] py-1"
+            >
+              회원가입
+            </Link>
           </div>
         </form>
 
         <div className="flex items-center gap-3 mt-8 mb-4 text-grey-500">
           <div className="flex-1 h-[1px] bg-grey-200" />
-          <span className="text-[11px] font-semibold tracking-[0.5px] whitespace-nowrap uppercase">오늘의 밥친구 추천</span>
+          <span className="text-[11px] font-semibold tracking-[0.5px] whitespace-nowrap uppercase">
+            오늘의 밥친구 추천
+          </span>
           <div className="flex-1 h-[1px] bg-grey-200" />
         </div>
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TopBar } from "@/components/layout/TopBar";
+import { Card } from "@/components/common/Card";
+import { authService } from "@/services/auth.service";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+interface LoginForm {
+  emailId: string;
+  password: string;
+}
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { setAuth, isAuthenticated, _hasHydrated } = useAuthStore();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginForm>();
+
+  const onSubmit = handleSubmit(async ({ emailId, password }) => {
+    try {
+      const fullEmail = emailId.includes("@") ? emailId : `${emailId}@skhu.ac.kr`;
+      const { user, token } = await authService.login(fullEmail, password);
+      setAuth(user, token);
+      router.replace("/");
+    } catch (err) {
+      setError("root", {
+        message: err instanceof Error ? err.message : "로그인에 실패했습니다.",
+      });
+    }
+  });
+
+  if (!_hasHydrated) {
+    return <div className="flex flex-col flex-1 bg-white h-full" />;
+  }
+
+  if (isAuthenticated) {
+    router.replace("/");
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col flex-1 bg-white animate-fade-slide-up h-full">
+      <TopBar
+        showLogo
+        rightAction={<button className="text-[14px] font-medium text-grey-600 px-[10px] py-[6px]">도움말</button>}
+      />
+
+      <main className="flex-1 overflow-y-auto px-6 py-7 flex flex-col no-scrollbar">
+        <section className="mb-8">
+          <h1 className="text-[26px] font-bold text-grey-900 leading-[36px] tracking-[-0.6px] mb-2">
+            오늘 점심,<br />
+            <span className="hl">같이 먹을 친구</span>를<br />
+            찾아보세요
+          </h1>
+          <p className="text-[15px] text-grey-600 leading-[22px]">
+            학교 이메일로 간편하게 시작해요
+          </p>
+        </section>
+
+        <form onSubmit={onSubmit} className="space-y-5">
+          <div className="space-y-1.5">
+            <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+              이메일
+            </span>
+            <div className="relative flex items-center">
+              <Input
+                {...register("emailId", {
+                  required: "이메일을 입력해주세요",
+                  pattern: {
+                    value: /^[a-zA-Z0-9._-]+$/,
+                    message: "올바른 학번 또는 아이디를 입력해주세요",
+                  },
+                })}
+                className="pr-24"
+                placeholder="학번 또는 이메일"
+                disabled={isSubmitting}
+              />
+              <span className="absolute right-4 text-[13px] font-medium text-grey-400">
+                @skhu.ac.kr
+              </span>
+            </div>
+            {errors.emailId && (
+              <p className="text-sm font-medium text-red-500 animate-in fade-in slide-in-from-top-1">
+                {errors.emailId.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+              비밀번호
+            </span>
+            <Input
+              {...register("password", {
+                required: "비밀번호를 입력해주세요",
+                minLength: { value: 8, message: "비밀번호는 8자 이상이어야 해요" },
+              })}
+              type="password"
+              placeholder="비밀번호 입력"
+              disabled={isSubmitting}
+            />
+            {errors.password && (
+              <p className="text-sm font-medium text-red-500 animate-in fade-in slide-in-from-top-1">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          {errors.root && (
+            <p className="text-sm font-medium text-red-500 animate-in fade-in slide-in-from-top-1">
+              {errors.root.message}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-full mt-2"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "로그인 중..." : "로그인"}
+          </Button>
+
+          <div className="flex items-center justify-center gap-0 mt-4">
+            <Link href="#" className="text-[13px] font-medium text-grey-600 px-[10px] py-1">아이디 찾기</Link>
+            <span className="text-grey-300 text-[13px]">|</span>
+            <Link href="#" className="text-[13px] font-medium text-grey-600 px-[10px] py-1">비밀번호 재설정</Link>
+            <span className="text-grey-300 text-[13px]">|</span>
+            <Link href="/signup" className="text-[13px] font-bold text-grey-900 px-[10px] py-1">회원가입</Link>
+          </div>
+        </form>
+
+        <div className="flex items-center gap-3 mt-8 mb-4 text-grey-500">
+          <div className="flex-1 h-[1px] bg-grey-200" />
+          <span className="text-[11px] font-semibold tracking-[0.5px] whitespace-nowrap uppercase">오늘의 밥친구 추천</span>
+          <div className="flex-1 h-[1px] bg-grey-200" />
+        </div>
+
+        <div className="space-y-[10px] mb-8">
+          <Card
+            thumbnail="🍜"
+            category="분식"
+            status="active"
+            time="12:15"
+            title="부대찌개 + 공기밥"
+            location="학생회관 1층"
+            currentParticipants={3}
+            maxParticipants={4}
+            avatars={[]}
+          />
+          <Card
+            thumbnail="🍣"
+            category="일식"
+            status="active"
+            time="13:00"
+            title="스시로 런치세트"
+            location="정문 스시로"
+            currentParticipants={2}
+            maxParticipants={4}
+            avatars={[]}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -126,9 +126,9 @@ export default function LoginPage() {
             <Input
               {...register("password", {
                 required: "비밀번호를 입력해주세요",
-                minLength: {
-                  value: 8,
-                  message: "비밀번호는 8자 이상이어야 해요",
+                pattern: {
+                  value: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/,
+                  message: "영문, 숫자, 특수문자(@$!%*#?&)를 포함해 8자 이상 입력해주세요",
                 },
               })}
               type="password"

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -18,6 +19,12 @@ interface LoginForm {
 export default function LoginPage() {
   const router = useRouter();
   const { setAuth, isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && isAuthenticated) {
+      router.replace("/");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
 
   const {
     register,
@@ -42,16 +49,25 @@ export default function LoginPage() {
   });
 
   if (!_hasHydrated) {
-    return <div className="flex flex-col flex-1 bg-white h-full" />;
+    return (
+      <div className="flex flex-col flex-1 bg-white">
+        <TopBar showLogo />
+        <div className="flex-1" />
+      </div>
+    );
   }
 
   if (isAuthenticated) {
-    router.replace("/");
-    return null;
+    return (
+      <div className="flex flex-col flex-1 bg-white">
+        <TopBar showLogo />
+        <div className="flex-1" />
+      </div>
+    );
   }
 
   return (
-    <div className="flex flex-col flex-1 bg-white animate-fade-slide-up h-full">
+    <div className="flex flex-col flex-1 bg-white">
       <TopBar
         showLogo
         rightAction={
@@ -61,7 +77,7 @@ export default function LoginPage() {
         }
       />
 
-      <main className="flex-1 overflow-y-auto px-6 py-7 flex flex-col no-scrollbar">
+      <main className="flex-1 overflow-y-auto px-6 py-7 flex flex-col no-scrollbar animate-fade-slide-up">
         <section className="mb-8">
           <h1 className="text-[26px] font-bold text-grey-900 leading-[36px] tracking-[-0.6px] mb-2">
             오늘 점심,
@@ -84,12 +100,12 @@ export default function LoginPage() {
                 {...register("emailId", {
                   required: "이메일을 입력해주세요",
                   pattern: {
-                    value: /^[a-zA-Z0-9._-]+$/,
-                    message: "올바른 학번 또는 아이디를 입력해주세요",
+                    value: /^[a-zA-Z0-9._-]+(@skhu\.ac\.kr)?$/,
+                    message: "올바른 학번 또는 이메일을 입력해주세요",
                   },
                 })}
                 className="pr-24"
-                placeholder="학번 또는 이메일"
+                placeholder="학번 또는 아이디"
                 disabled={isSubmitting}
               />
               <span className="absolute right-4 text-[13px] font-medium text-grey-400">
@@ -157,7 +173,7 @@ export default function LoginPage() {
             </Link>
             <span className="text-grey-300 text-[13px]">|</span>
             <Link
-              href="/signup"
+              href="/register"
               className="text-[13px] font-bold text-grey-900 px-[10px] py-1"
             >
               회원가입

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -38,8 +38,8 @@ export default function LoginPage() {
       const fullEmail = emailId.includes("@")
         ? emailId
         : `${emailId}@skhu.ac.kr`;
-      const { user, token } = await authService.login(fullEmail, password);
-      setAuth(user, token);
+      const { user } = await authService.login(fullEmail, password);
+      setAuth(user);
       router.replace("/");
     } catch (err) {
       setError("root", {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Chip } from "@/components/common/Chip";
 import { authService } from "@/services/auth.service";
+import { useAuthStore } from "@/lib/store/useAuthStore";
 
 const FOOD_CATEGORIES = [
   { id: "면류", label: "🍜 면류" },
@@ -47,6 +48,7 @@ type Step = 1 | 2;
 
 export default function RegisterPage() {
   const router = useRouter();
+  const { setAuth } = useAuthStore();
   const [step, setStep] = useState<Step>(1);
 
   const [codeSent, setCodeSent] = useState(false);
@@ -65,6 +67,7 @@ export default function RegisterPage() {
   const {
     register: reg1,
     getValues: getStep1Values,
+    trigger: trigger1,
     formState: { errors: errors1 },
     handleSubmit: handleSubmit1,
   } = useForm<Step1Fields>();
@@ -83,8 +86,9 @@ export default function RegisterPage() {
   }, [watchedNickname]);
 
   const handleSendCode = async () => {
+    const valid = await trigger1("emailId");
+    if (!valid) return;
     const emailId = getStep1Values("emailId");
-    if (!emailId) return;
     setCodeError("");
     setCodeLoading(true);
     try {
@@ -142,7 +146,7 @@ export default function RegisterPage() {
     setApiError("");
     const { emailId, password } = getStep1Values();
     try {
-      await authService.register({
+      const { user, token } = await authService.register({
         email: `${emailId}@skhu.ac.kr`,
         password,
         nickname: data.nickname,
@@ -150,7 +154,8 @@ export default function RegisterPage() {
         admission_year: data.admissionYear,
         category: selectedCategories,
       });
-      router.push("/login");
+      setAuth(user, token);
+      router.replace("/");
     } catch {
       setApiError("회원가입에 실패했어요. 다시 시도해주세요.");
     }
@@ -202,7 +207,13 @@ export default function RegisterPage() {
               </span>
               <div className="relative flex items-center">
                 <Input
-                  {...reg1("emailId", { required: "이메일을 입력해주세요" })}
+                  {...reg1("emailId", {
+                    required: "이메일을 입력해주세요",
+                    pattern: {
+                      value: /^[a-zA-Z0-9._-]+$/,
+                      message: "올바른 학번 또는 아이디를 입력해주세요",
+                    },
+                  })}
                   placeholder="학번 또는 아이디"
                   disabled={codeVerified}
                   className="pr-28"
@@ -284,7 +295,10 @@ export default function RegisterPage() {
               <Input
                 {...reg1("password", {
                   required: "비밀번호를 입력해주세요",
-                  minLength: { value: 8, message: "8자 이상 입력해주세요" },
+                  pattern: {
+                    value: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/,
+                    message: "영문, 숫자, 특수문자(@$!%*#?&)를 포함해 8자 이상 입력해주세요",
+                  },
                 })}
                 type="password"
                 placeholder="8자 이상, 영문+숫자+특수문자"

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { ArrowLeft, CheckCircle2, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Chip } from "@/components/common/Chip";
+import { authService } from "@/services/auth.service";
+
+const FOOD_CATEGORIES = [
+  { id: "면류", label: "🍜 면류" },
+  { id: "한식", label: "🍚 한식" },
+  { id: "일식", label: "🍣 일식" },
+  { id: "양식", label: "🍕 양식" },
+  { id: "중식", label: "🥟 중식" },
+  { id: "분식", label: "🌯 분식" },
+];
+
+const DEPARTMENTS = [
+  "소프트웨어공학과",
+  "컴퓨터공학과",
+  "정보통신공학과",
+  "경영학과",
+  "경제학과",
+  "사회복지학과",
+  "영어학과",
+  "기계공학과",
+  "전자공학과",
+  "간호학과",
+  "기타",
+];
+
+interface Step1Fields {
+  emailId: string;
+  password: string;
+}
+
+interface Step2Fields {
+  nickname: string;
+  department: string;
+  admissionYear: string;
+}
+
+type Step = 1 | 2;
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>(1);
+
+  const [codeSent, setCodeSent] = useState(false);
+  const [code, setCode] = useState("");
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [codeError, setCodeError] = useState("");
+  const [codeLoading, setCodeLoading] = useState(false);
+
+  const [nicknameStatus, setNicknameStatus] = useState<"idle" | "ok" | "taken">("idle");
+  const [nicknameLoading, setNicknameLoading] = useState(false);
+
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+
+  const [apiError, setApiError] = useState("");
+
+  const {
+    register: reg1,
+    getValues: getStep1Values,
+    formState: { errors: errors1 },
+    handleSubmit: handleSubmit1,
+  } = useForm<Step1Fields>();
+
+  const {
+    register: reg2,
+    watch: watch2,
+    getValues: getStep2Values,
+    formState: { errors: errors2, isSubmitting: isSubmitting2 },
+    handleSubmit: handleSubmit2,
+  } = useForm<Step2Fields>();
+
+  const watchedNickname = watch2("nickname", "");
+  useEffect(() => {
+    setNicknameStatus("idle");
+  }, [watchedNickname]);
+
+  const handleSendCode = async () => {
+    const emailId = getStep1Values("emailId");
+    if (!emailId) return;
+    setCodeError("");
+    setCodeLoading(true);
+    try {
+      await authService.sendCode(`${emailId}@skhu.ac.kr`);
+      setCodeSent(true);
+    } catch {
+      setCodeError("인증코드 발송에 실패했어요.");
+    } finally {
+      setCodeLoading(false);
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    const emailId = getStep1Values("emailId");
+    setCodeError("");
+    setCodeLoading(true);
+    try {
+      await authService.verifyCode(`${emailId}@skhu.ac.kr`, code);
+      setCodeVerified(true);
+    } catch {
+      setCodeError("인증코드가 올바르지 않아요.");
+    } finally {
+      setCodeLoading(false);
+    }
+  };
+
+  const handleCheckNickname = async () => {
+    const nickname = getStep2Values("nickname");
+    if (!nickname) return;
+    setNicknameLoading(true);
+    try {
+      await authService.checkNickname(nickname);
+      setNicknameStatus("ok");
+    } catch {
+      setNicknameStatus("taken");
+    } finally {
+      setNicknameLoading(false);
+    }
+  };
+
+  const onStep1Submit = handleSubmit1(() => {
+    if (!codeVerified) {
+      setCodeError("이메일 인증을 완료해주세요.");
+      return;
+    }
+    setApiError("");
+    setStep(2);
+  });
+
+  const onStep2Submit = handleSubmit2(async (data) => {
+    if (nicknameStatus !== "ok") {
+      setApiError("닉네임 중복확인을 완료해주세요.");
+      return;
+    }
+    setApiError("");
+    const { emailId, password } = getStep1Values();
+    try {
+      await authService.register({
+        email: `${emailId}@skhu.ac.kr`,
+        password,
+        nickname: data.nickname,
+        department: data.department,
+        admission_year: data.admissionYear,
+        category: selectedCategories,
+      });
+      router.push("/login");
+    } catch {
+      setApiError("회원가입에 실패했어요. 다시 시도해주세요.");
+    }
+  });
+
+  const toggleCategory = (id: string) => {
+    setSelectedCategories((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
+    );
+  };
+
+  return (
+    <div className="flex flex-col flex-1 bg-white h-full">
+      <header className="flex items-center justify-between px-2 py-1 h-[52px] shrink-0">
+        <button
+          onClick={() => (step === 1 ? router.push("/login") : setStep(1))}
+          className="w-11 h-11 flex items-center justify-center rounded-[12px] text-grey-700 active:bg-grey-100"
+        >
+          <ArrowLeft className="w-[22px] h-[22px]" />
+        </button>
+        <span className="text-[13px] font-semibold text-grey-500 pr-4">
+          {step} / 2
+        </span>
+      </header>
+
+      <div className="flex gap-1.5 px-5 pb-1">
+        {([1, 2] as Step[]).map((s) => (
+          <div
+            key={s}
+            className={`h-[3px] flex-1 rounded-full transition-colors ${
+              step >= s ? "bg-primary-500" : "bg-grey-200"
+            }`}
+          />
+        ))}
+      </div>
+
+      <main className="flex-1 overflow-y-auto px-5 pt-8 pb-6 no-scrollbar">
+        {step === 1 && (
+          <form id="step1-form" onSubmit={onStep1Submit} className="space-y-5">
+            <h1 className="text-[26px] font-bold text-grey-900 leading-[34px] tracking-[-0.5px] mb-8">
+              학교 이메일로
+              <br />
+              시작해볼까요?
+            </h1>
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                이메일
+              </span>
+              <div className="relative flex items-center">
+                <Input
+                  {...reg1("emailId", { required: "이메일을 입력해주세요" })}
+                  placeholder="학번 또는 아이디"
+                  disabled={codeVerified}
+                  className="pr-28"
+                  onChange={(e) => {
+                    reg1("emailId").onChange(e);
+                    setCodeSent(false);
+                    setCodeVerified(false);
+                  }}
+                />
+                <span className="absolute right-4 text-[13px] font-medium text-grey-400 pointer-events-none">
+                  @skhu.ac.kr
+                </span>
+              </div>
+              {errors1.emailId && (
+                <p className="text-[12px] text-red-500 px-1">{errors1.emailId.message}</p>
+              )}
+              {!codeVerified && (
+                <Button
+                  type="button"
+                  variant={codeSent ? "weakPrimary" : "primary"}
+                  size="pill"
+                  onClick={handleSendCode}
+                  disabled={codeLoading}
+                >
+                  {codeSent ? "재발송" : "인증코드 발송"}
+                </Button>
+              )}
+            </div>
+
+            {codeSent && !codeVerified && (
+              <div className="space-y-2">
+                <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                  인증코드
+                </span>
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="6자리 숫자 입력"
+                    value={code}
+                    onChange={(e) =>
+                      setCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                    }
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="weakPrimary"
+                    size="pill"
+                    onClick={handleVerifyCode}
+                    disabled={code.length !== 6 || codeLoading}
+                    className="shrink-0"
+                  >
+                    확인
+                  </Button>
+                </div>
+                <p className="text-[12px] text-grey-400 px-1">
+                  테스트 코드: <strong className="text-grey-700">123456</strong>
+                </p>
+              </div>
+            )}
+
+            {codeVerified && (
+              <p className="flex items-center gap-1.5 text-[13px] font-semibold text-green-600">
+                <CheckCircle2 className="w-4 h-4" />
+                이메일 인증이 완료됐어요
+              </p>
+            )}
+
+            {codeError && (
+              <p className="flex items-center gap-1.5 text-[13px] text-red-500">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {codeError}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                비밀번호
+              </span>
+              <Input
+                {...reg1("password", {
+                  required: "비밀번호를 입력해주세요",
+                  minLength: { value: 8, message: "8자 이상 입력해주세요" },
+                })}
+                type="password"
+                placeholder="8자 이상, 영문+숫자+특수문자"
+              />
+              {errors1.password && (
+                <p className="text-[12px] text-red-500 px-1">{errors1.password.message}</p>
+              )}
+            </div>
+          </form>
+        )}
+
+        {step === 2 && (
+          <form id="step2-form" onSubmit={onStep2Submit} className="space-y-5">
+            <h1 className="text-[26px] font-bold text-grey-900 leading-[34px] tracking-[-0.5px] mb-8">
+              나를 소개해주세요
+            </h1>
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                닉네임
+              </span>
+              <div className="flex gap-2">
+                <Input
+                  {...reg2("nickname", {
+                    required: "닉네임을 입력해주세요",
+                    maxLength: { value: 10, message: "최대 10자까지 입력 가능해요" },
+                  })}
+                  placeholder="예) 밥순이 (최대 10자)"
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="weakPrimary"
+                  size="pill"
+                  onClick={handleCheckNickname}
+                  disabled={!watchedNickname || nicknameLoading}
+                  className="shrink-0"
+                >
+                  중복확인
+                </Button>
+              </div>
+              {errors2.nickname && (
+                <p className="text-[12px] text-red-500 px-1">{errors2.nickname.message}</p>
+              )}
+              {nicknameStatus === "ok" && (
+                <p className="flex items-center gap-1 text-[12px] font-semibold text-green-600 px-1">
+                  <CheckCircle2 className="w-3.5 h-3.5" /> 사용 가능한 닉네임이에요
+                </p>
+              )}
+              {nicknameStatus === "taken" && (
+                <p className="flex items-center gap-1 text-[12px] font-semibold text-red-500 px-1">
+                  <AlertCircle className="w-3.5 h-3.5" /> 이미 사용 중인 닉네임이에요
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                학과
+              </span>
+              <div className="relative">
+                <select
+                  {...reg2("department", { required: "학과를 선택해주세요" })}
+                  className="w-full h-[52px] bg-grey-100 border-none rounded-[14px] px-4 text-[16px] text-grey-900 appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-300"
+                >
+                  <option value="">학과를 선택해주세요</option>
+                  {DEPARTMENTS.map((d) => (
+                    <option key={d} value={d}>{d}</option>
+                  ))}
+                </select>
+                <span className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 text-lg">›</span>
+              </div>
+              {errors2.department && (
+                <p className="text-[12px] text-red-500 px-1">{errors2.department.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                입학연도
+              </span>
+              <div className="relative">
+                <select
+                  {...reg2("admissionYear", { required: "입학연도를 선택해주세요" })}
+                  className="w-full h-[52px] bg-grey-100 border-none rounded-[14px] px-4 text-[16px] text-grey-900 appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-300"
+                >
+                  <option value="">입학연도를 선택해주세요</option>
+                  {Array.from({ length: 10 }, (_, i) => 2026 - i).map((y) => (
+                    <option key={y} value={String(y)}>
+                      {y}년 ({String(y).slice(2)}학번)
+                    </option>
+                  ))}
+                </select>
+                <span className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 text-lg">›</span>
+              </div>
+              {errors2.admissionYear && (
+                <p className="text-[12px] text-red-500 px-1">{errors2.admissionYear.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <span className="text-[11px] font-bold text-grey-500 tracking-[1.2px] uppercase">
+                선호 음식
+              </span>
+              <p className="text-[12px] text-grey-400">복수 선택 가능해요</p>
+              <div className="flex flex-wrap gap-2">
+                {FOOD_CATEGORIES.map((cat) => (
+                  <Chip
+                    key={cat.id}
+                    active={selectedCategories.includes(cat.id)}
+                    onClick={() => toggleCategory(cat.id)}
+                  >
+                    {cat.label}
+                  </Chip>
+                ))}
+              </div>
+            </div>
+
+            {apiError && (
+              <p className="flex items-center gap-1.5 text-[13px] text-red-500">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {apiError}
+              </p>
+            )}
+          </form>
+        )}
+      </main>
+
+      <div className="px-5 pb-8 pt-4 shrink-0">
+        {step === 1 ? (
+          <Button form="step1-form" type="submit" className="w-full">
+            다음
+          </Button>
+        ) : (
+          <Button
+            form="step2-form"
+            type="submit"
+            className="w-full"
+            disabled={nicknameStatus !== "ok" || isSubmitting2}
+          >
+            {isSubmitting2 ? "가입 중..." : "시작하기"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -112,7 +112,11 @@ export default function RegisterPage() {
     setCodeError("");
     setCodeLoading(true);
     try {
-      await authService.verifyCode(`${emailId}@skhu.ac.kr`, code);
+      const result = await authService.verifyCode(`${emailId}@skhu.ac.kr`, code);
+      if (!result.verified) {
+        setCodeError("인증코드가 올바르지 않아요.");
+        return;
+      }
       setCodeVerified(true);
     } catch {
       setCodeError("인증코드가 올바르지 않아요.");
@@ -152,7 +156,7 @@ export default function RegisterPage() {
     setApiError("");
     const { emailId, password } = getStep1Values();
     try {
-      const { user, token } = await authService.register({
+      const { user } = await authService.register({
         email: `${emailId}@skhu.ac.kr`,
         password,
         nickname: data.nickname,
@@ -160,7 +164,7 @@ export default function RegisterPage() {
         admissionYear: data.admissionYear,
         category: selectedCategories,
       });
-      setAuth(user, token);
+      setAuth(user);
       router.replace("/");
     } catch {
       setApiError("회원가입에 실패했어요. 다시 시도해주세요.");
@@ -292,9 +296,11 @@ export default function RegisterPage() {
                     확인
                   </Button>
                 </div>
-                <p className="text-[12px] text-grey-400 px-1">
-                  테스트 코드: <strong className="text-grey-700">123456</strong>
-                </p>
+                {process.env.NODE_ENV === "development" && (
+                  <p className="text-[12px] text-grey-400 px-1">
+                    테스트 코드: <strong className="text-grey-700">123456</strong>
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -48,8 +48,14 @@ type Step = 1 | 2;
 
 export default function RegisterPage() {
   const router = useRouter();
-  const { setAuth } = useAuthStore();
+  const { setAuth, isAuthenticated, _hasHydrated } = useAuthStore();
   const [step, setStep] = useState<Step>(1);
+
+  useEffect(() => {
+    if (_hasHydrated && isAuthenticated) {
+      router.replace("/");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
 
   const [codeSent, setCodeSent] = useState(false);
   const [code, setCode] = useState("");
@@ -167,8 +173,26 @@ export default function RegisterPage() {
     );
   };
 
+  if (!_hasHydrated) {
+    return (
+      <div className="flex flex-col flex-1 bg-white">
+        <header className="h-[52px]" />
+        <div className="flex-1" />
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return (
+      <div className="flex flex-col flex-1 bg-white">
+        <header className="h-[52px]" />
+        <div className="flex-1" />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col flex-1 bg-white h-full">
+    <div className="flex flex-col flex-1 bg-white">
       <header className="flex items-center justify-between px-2 py-1 h-[52px] shrink-0">
         <button
           onClick={() => (step === 1 ? router.push("/login") : setStep(1))}
@@ -192,7 +216,7 @@ export default function RegisterPage() {
         ))}
       </div>
 
-      <main className="flex-1 overflow-y-auto px-5 pt-8 pb-6 no-scrollbar">
+      <main className="flex-1 overflow-y-auto px-5 pt-8 pb-6 no-scrollbar animate-fade-slide-up">
         {step === 1 && (
           <form id="step1-form" onSubmit={onStep1Submit} className="space-y-5">
             <h1 className="text-[26px] font-bold text-grey-900 leading-[34px] tracking-[-0.5px] mb-8">
@@ -210,8 +234,8 @@ export default function RegisterPage() {
                   {...reg1("emailId", {
                     required: "이메일을 입력해주세요",
                     pattern: {
-                      value: /^[a-zA-Z0-9._-]+$/,
-                      message: "올바른 학번 또는 아이디를 입력해주세요",
+                      value: /^[a-zA-Z0-9._-]+(@skhu\.ac\.kr)?$/,
+                      message: "올바른 학번 또는 이메일을 입력해주세요",
                     },
                   })}
                   placeholder="학번 또는 아이디"

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -130,8 +130,8 @@ export default function RegisterPage() {
     if (!nickname) return;
     setNicknameLoading(true);
     try {
-      await authService.checkNickname(nickname);
-      setNicknameStatus("ok");
+      const { available } = await authService.checkNickname(nickname);
+      setNicknameStatus(available ? "ok" : "taken");
     } catch {
       setNicknameStatus("taken");
     } finally {
@@ -161,7 +161,7 @@ export default function RegisterPage() {
         password,
         nickname: data.nickname,
         department: data.department,
-        admissionYear: data.admissionYear,
+        admission_year: data.admissionYear,
         category: selectedCategories,
       });
       setAuth(user);

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -157,7 +157,7 @@ export default function RegisterPage() {
         password,
         nickname: data.nickname,
         department: data.department,
-        admission_year: data.admissionYear,
+        admissionYear: data.admissionYear,
         category: selectedCategories,
       });
       setAuth(user, token);

--- a/src/app/auth/[...path]/route.ts
+++ b/src/app/auth/[...path]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { proxyRequest } from "@/lib/api-proxy";
 
-export const GET = (req: NextRequest) => proxyRequest(req);
-export const POST = (req: NextRequest) => proxyRequest(req);
-export const PUT = (req: NextRequest) => proxyRequest(req);
-export const PATCH = (req: NextRequest) => proxyRequest(req);
-export const DELETE = (req: NextRequest) => proxyRequest(req);
+export const GET = async (req: NextRequest) => await proxyRequest(req);
+export const POST = async (req: NextRequest) => await proxyRequest(req);
+export const PUT = async (req: NextRequest) => await proxyRequest(req);
+export const PATCH = async (req: NextRequest) => await proxyRequest(req);
+export const DELETE = async (req: NextRequest) => await proxyRequest(req);

--- a/src/app/auth/[...path]/route.ts
+++ b/src/app/auth/[...path]/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { proxyRequest } from "@/lib/api-proxy";
+
+export const GET = (req: NextRequest) => proxyRequest(req);
+export const POST = (req: NextRequest) => proxyRequest(req);
+export const PUT = (req: NextRequest) => proxyRequest(req);
+export const PATCH = (req: NextRequest) => proxyRequest(req);
+export const DELETE = (req: NextRequest) => proxyRequest(req);

--- a/src/app/auth/login/route.ts
+++ b/src/app/auth/login/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverFetchRaw } from "@/lib/fetch";
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const { status, data } = await serverFetchRaw("/auth/login", undefined, {
+    method: "POST",
+    body,
+  });
+
+  const d = data as Record<string, unknown>;
+  if (status !== 200 || !d.token) {
+    return NextResponse.json(data, { status });
+  }
+
+  const { token, ...rest } = d;
+  const res = NextResponse.json(rest, { status });
+
+  res.cookies.set("auth-token", token as string, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  });
+
+  return res;
+}

--- a/src/app/auth/login/route.ts
+++ b/src/app/auth/login/route.ts
@@ -9,20 +9,30 @@ export async function POST(req: NextRequest) {
   });
 
   const d = data as Record<string, unknown>;
-  if (status !== 200 || !d.token) {
+  if (status < 200 || status >= 300 || !d.access_token) {
     return NextResponse.json(data, { status });
   }
 
-  const { token, ...rest } = d;
+  const { access_token, refresh_token, ...rest } = d;
   const res = NextResponse.json(rest, { status });
 
-  res.cookies.set("auth-token", token as string, {
+  res.cookies.set("auth-token", access_token as string, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 24 * 7,
   });
+
+  if (refresh_token) {
+    res.cookies.set("refresh-token", refresh_token as string, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  }
 
   return res;
 }

--- a/src/app/auth/logout/route.ts
+++ b/src/app/auth/logout/route.ts
@@ -1,7 +1,25 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { serverFetchRaw } from "@/lib/fetch";
 
 export async function POST() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("auth-token")?.value;
+  const refreshToken = cookieStore.get("refresh-token")?.value;
+
+  if (refreshToken) {
+    await serverFetchRaw("/auth/logout", undefined, {
+      method: "POST",
+      body: JSON.stringify({ refresh_token: refreshToken }),
+      headers: {
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+    });
+  }
+
   const res = NextResponse.json({ message: "로그아웃 되었습니다." });
   res.cookies.delete("auth-token");
+  res.cookies.delete("refresh-token");
   return res;
 }

--- a/src/app/auth/logout/route.ts
+++ b/src/app/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = NextResponse.json({ message: "로그아웃 되었습니다." });
+  res.cookies.delete("auth-token");
+  return res;
+}

--- a/src/app/auth/refresh/route.ts
+++ b/src/app/auth/refresh/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { serverFetchRaw } from "@/lib/fetch";
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get("refresh-token")?.value;
+
+  if (!refreshToken) {
+    return NextResponse.json({ message: "refresh_token이 없습니다." }, { status: 401 });
+  }
+
+  const { status, data } = await serverFetchRaw("/auth/refresh", undefined, {
+    method: "POST",
+    body: JSON.stringify({ refresh_token: refreshToken }),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const d = data as Record<string, unknown>;
+  if (status < 200 || status >= 300 || !d.access_token) {
+    const res = NextResponse.json(data, { status });
+    res.cookies.delete("auth-token");
+    res.cookies.delete("refresh-token");
+    return res;
+  }
+
+  const res = NextResponse.json({ message: "토큰이 갱신됐어요." });
+  res.cookies.set("auth-token", d.access_token as string, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  });
+
+  return res;
+}

--- a/src/app/auth/register/route.ts
+++ b/src/app/auth/register/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverFetchRaw } from "@/lib/fetch";
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const { status, data } = await serverFetchRaw("/auth/register", undefined, {
+    method: "POST",
+    body,
+  });
+
+  const d = data as Record<string, unknown>;
+  if (status !== 200 && status !== 201) {
+    return NextResponse.json(data, { status });
+  }
+
+  if (!d.token) {
+    return NextResponse.json(data, { status });
+  }
+
+  const { token, ...rest } = d;
+  const res = NextResponse.json(rest, { status });
+
+  res.cookies.set("auth-token", token as string, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  });
+
+  return res;
+}

--- a/src/app/auth/register/route.ts
+++ b/src/app/auth/register/route.ts
@@ -9,18 +9,14 @@ export async function POST(req: NextRequest) {
   });
 
   const d = data as Record<string, unknown>;
-  if (status !== 200 && status !== 201) {
+  if (status < 200 || status >= 300 || !d.access_token) {
     return NextResponse.json(data, { status });
   }
 
-  if (!d.token) {
-    return NextResponse.json(data, { status });
-  }
-
-  const { token, ...rest } = d;
+  const { access_token, ...rest } = d;
   const res = NextResponse.json(rest, { status });
 
-  res.cookies.set("auth-token", token as string, {
+  res.cookies.set("auth-token", access_token as string, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { TopBar } from "@/components/layout/TopBar";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+export default function ChatPage() {
+  const router = useRouter();
+  const { isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
+
+  if (!_hasHydrated || !isAuthenticated) {
+    return <div className="flex-1 bg-white" />;
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <TopBar title="채팅" />
+      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+        <p className="text-[14px] text-grey-400">준비 중이에요</p>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
-import { useAuthStore } from "@/lib/store/useAuthStore";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 export default function ChatPage() {
-  const router = useRouter();
-  const { isAuthenticated, _hasHydrated } = useAuthStore();
-
-  useEffect(() => {
-    if (_hasHydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [_hasHydrated, isAuthenticated, router]);
-
-  if (!_hasHydrated || !isAuthenticated) {
-    return <div className="flex-1 bg-white" />;
-  }
-
   return (
-    <div className="flex flex-col h-full bg-white">
-      <TopBar title="채팅" />
-      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
-        <p className="text-[14px] text-grey-400">준비 중이에요</p>
-      </main>
-      <BottomNav />
-    </div>
+    <AuthGuard title="채팅">
+      <div className="flex flex-col h-full bg-white">
+        <TopBar title="채팅" />
+        <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+          <p className="text-[14px] text-grey-400">준비 중이에요</p>
+        </main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
-import { useAuthStore } from "@/lib/store/useAuthStore";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 export default function CreatePage() {
-  const router = useRouter();
-  const { isAuthenticated, _hasHydrated } = useAuthStore();
-
-  useEffect(() => {
-    if (_hasHydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [_hasHydrated, isAuthenticated, router]);
-
-  if (!_hasHydrated || !isAuthenticated) {
-    return <div className="flex-1 bg-white" />;
-  }
-
   return (
-    <div className="flex flex-col h-full bg-white">
-      <TopBar title="밥자리 만들기" />
-      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
-        <p className="text-[14px] text-grey-400">준비 중이에요</p>
-      </main>
-      <BottomNav />
-    </div>
+    <AuthGuard title="밥자리 만들기">
+      <div className="flex flex-col h-full bg-white">
+        <TopBar title="밥자리 만들기" />
+        <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+          <p className="text-[14px] text-grey-400">준비 중이에요</p>
+        </main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { TopBar } from "@/components/layout/TopBar";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+export default function CreatePage() {
+  const router = useRouter();
+  const { isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
+
+  if (!_hasHydrated || !isAuthenticated) {
+    return <div className="flex-1 bg-white" />;
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <TopBar title="밥자리 만들기" />
+      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+        <p className="text-[14px] text-grey-400">준비 중이에요</p>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { TopBar } from "@/components/layout/TopBar";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+export default function FriendsPage() {
+  const router = useRouter();
+  const { isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
+
+  if (!_hasHydrated || !isAuthenticated) {
+    return <div className="flex-1 bg-white" />;
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <TopBar title="밥친구" />
+      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+        <p className="text-[14px] text-grey-400">준비 중이에요</p>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
-import { useAuthStore } from "@/lib/store/useAuthStore";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 export default function FriendsPage() {
-  const router = useRouter();
-  const { isAuthenticated, _hasHydrated } = useAuthStore();
-
-  useEffect(() => {
-    if (_hasHydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [_hasHydrated, isAuthenticated, router]);
-
-  if (!_hasHydrated || !isAuthenticated) {
-    return <div className="flex-1 bg-white" />;
-  }
-
   return (
-    <div className="flex flex-col h-full bg-white">
-      <TopBar title="밥친구" />
-      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
-        <p className="text-[14px] text-grey-400">준비 중이에요</p>
-      </main>
-      <BottomNav />
-    </div>
+    <AuthGuard title="밥친구">
+      <div className="flex flex-col h-full bg-white">
+        <TopBar title="밥친구" />
+        <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+          <p className="text-[14px] text-grey-400">준비 중이에요</p>
+        </main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,33 @@
 @import "tailwindcss";
 @import "../styles/globals.css";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+
+@custom-variant dark (&:is(.dark *));
 
 @theme {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+
+  --color-primary: var(--primary-500);
+  --color-primary-foreground: var(--grey-900);
+
+  --color-secondary: var(--grey-100);
+  --color-secondary-foreground: var(--grey-900);
+
+  --color-muted: var(--grey-100);
+  --color-muted-foreground: var(--grey-500);
+
+  --color-accent: var(--primary-100);
+  --color-accent-foreground: var(--primary-700);
+
+  --color-destructive: var(--red-500);
+  --color-destructive-foreground: var(--white);
+
+  --color-border: var(--grey-200);
+  --color-input: var(--grey-200);
+  --color-ring: var(--primary-500);
+
   --color-primary-50: var(--primary-50);
   --color-primary-100: var(--primary-100);
   --color-primary-200: var(--primary-200);
@@ -52,11 +78,34 @@
 :root {
   --background: var(--white);
   --foreground: var(--grey-900);
+  --card: var(--white);
+  --card-foreground: var(--grey-900);
+  --popover: var(--white);
+  --popover-foreground: var(--grey-900);
+  --primary: var(--primary-500);
+  --primary-foreground: var(--grey-900);
+  --secondary: var(--grey-100);
+  --secondary-foreground: var(--grey-900);
+  --muted: var(--grey-100);
+  --muted-foreground: var(--grey-500);
+  --accent: var(--primary-100);
+  --accent-foreground: var(--primary-700);
+  --destructive: var(--red-500);
+  --destructive-foreground: var(--white);
+  --border: var(--grey-200);
+  --input: var(--grey-200);
+  --ring: var(--primary-500);
+  --radius: 1rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: var(--grey-900);
-    --foreground: var(--grey-50);
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+  html {
+    @apply font-sans;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+import { Geist } from "next/font/google";
+import { cn } from "@/lib/utils";
+
+const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
 export const metadata: Metadata = {
   title: '나랑 밥 먹을래? | 성공회대 밥친구',
@@ -20,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko" className="h-full">
+    <html lang="ko" className={cn("h-full", "font-sans", geist.variable)}>
       <head>
         <link
           rel="stylesheet"

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "페이지를 찾을 수 없어요 | 성공회대 밥친구",
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col flex-1 items-center justify-center gap-4 bg-white">
+      <p className="text-5xl">🍽️</p>
+      <h1 className="text-[20px] font-bold text-grey-900">페이지를 찾을 수 없어요</h1>
+      <p className="text-[14px] text-grey-500">요청하신 페이지가 존재하지 않아요</p>
+      <Link
+        href="/"
+        className="mt-2 px-6 py-2.5 rounded-full bg-primary text-grey-900 text-[14px] font-semibold"
+      >
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,107 @@
-import Image from "next/image";
+"use client";
 
-export default function Home() {
+import { useLayoutEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bell } from "lucide-react";
+import { TopBar } from "@/components/layout/TopBar";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { Card } from "@/components/common/Card";
+import { Chip } from "@/components/common/Chip";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+export default function HomePage() {
+  const router = useRouter();
+  const { user, isAuthenticated, _hasHydrated } = useAuthStore();
+  const [ready, setReady] = useState(false);
+
+  useLayoutEffect(() => {
+    setReady(true);
+  }, []);
+
+  if (!ready || !_hasHydrated) {
+    return <div className="flex flex-col h-full bg-white" />;
+  }
+
+  if (!isAuthenticated) {
+    router.replace("/login");
+    return null;
+  }
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+    <div className="flex flex-col h-full bg-white animate-fade-slide-up">
+      <TopBar
+        showLogo
+        rightAction={
+          <div className="relative p-2 cursor-pointer">
+            <Bell className="w-[22px] h-[22px] text-grey-700" />
+            <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-[1.5px] border-white" />
+          </div>
+        }
+      />
+
+      <main className="flex-1 overflow-y-auto no-scrollbar">
+        <section className="px-5 py-6 bg-white">
+          <h1 className="text-2xl font-bold text-grey-900 leading-8 tracking-tight">
+            {user?.nickname}님,<br />
+            오늘 점심 같이 먹을래요?
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+          <div className="flex items-center gap-1 mt-2.5 text-[13px] font-medium text-grey-600">
+            <span>모집 중 <strong className="font-bold text-grey-900">3</strong></span>
+            <div className="w-0.5 h-0.5 rounded-full bg-grey-400 mx-1" />
+            <span>마감 임박 <strong className="font-bold text-grey-900">1</strong></span>
+          </div>
+        </section>
+
+        <div className="h-2 bg-grey-100" />
+
+        <section className="px-5 py-3 flex gap-2 overflow-x-auto no-scrollbar bg-white sticky top-0 z-10 border-b border-grey-50">
+          <Chip active>전체</Chip>
+          <Chip>점심</Chip>
+          <Chip>저녁</Chip>
+          <Chip>학생회관</Chip>
+          <Chip>정문</Chip>
+          <Chip>한식</Chip>
+          <Chip>일식</Chip>
+        </section>
+
+        <section className="flex-1 bg-grey-50 px-5 py-4 space-y-2.5 min-h-screen">
+          <Card
+            thumbnail="🍲"
+            category="한식"
+            status="urgent"
+            time="12:15"
+            title="부대찌개 + 공기밥"
+            location="학생회관 1층"
+            currentParticipants={3}
+            maxParticipants={4}
+            avatars={[]}
+          />
+          <Card
+            thumbnail="🥘"
+            category="한식"
+            status="active"
+            time="12:30"
+            title="김치찌개 + 공기밥"
+            location="정문 앞 한솥"
+            currentParticipants={1}
+            maxParticipants={3}
+            avatars={[]}
+          />
+          <Card
+            thumbnail="🍣"
+            category="일식"
+            status="active"
+            time="13:00"
+            title="스시로 런치세트"
+            location="정문 스시로"
+            currentParticipants={2}
+            maxParticipants={4}
+            avatars={[]}
+          />
+        </section>
       </main>
+
+      <BottomNav />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
 import { TopBar } from "@/components/layout/TopBar";
@@ -12,14 +12,17 @@ import { useAuthStore } from "@/lib/store/useAuthStore";
 export default function HomePage() {
   const router = useRouter();
   const { user, isAuthenticated, _hasHydrated } = useAuthStore();
-  const [ready, setReady] = useState(false);
 
-  useLayoutEffect(() => {
-    setReady(true);
-  }, []);
+  const [isMounted, setIsMounted] = useState(
+    () => typeof window !== "undefined" && useAuthStore.getState()._hasHydrated,
+  );
 
-  if (!ready || !_hasHydrated) {
-    return <div className="flex flex-col h-full bg-white" />;
+  useEffect(() => {
+    if (!isMounted) setIsMounted(true);
+  }, [isMounted]);
+
+  if (!isMounted || !_hasHydrated) {
+    return <div className="flex-1 bg-white" />;
   }
 
   if (!isAuthenticated) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function HomePage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-white animate-fade-slide-up">
+    <div className="flex flex-col h-full bg-white">
       <TopBar
         showLogo
         rightAction={

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
 import { TopBar } from "@/components/layout/TopBar";
@@ -13,21 +13,14 @@ export default function HomePage() {
   const router = useRouter();
   const { user, isAuthenticated, _hasHydrated } = useAuthStore();
 
-  const [isMounted, setIsMounted] = useState(
-    () => typeof window !== "undefined" && useAuthStore.getState()._hasHydrated,
-  );
-
   useEffect(() => {
-    if (!isMounted) setIsMounted(true);
-  }, [isMounted]);
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
 
-  if (!isMounted || !_hasHydrated) {
+  if (!_hasHydrated || !isAuthenticated) {
     return <div className="flex-1 bg-white" />;
-  }
-
-  if (!isAuthenticated) {
-    router.replace("/login");
-    return null;
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,92 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { Card } from "@/components/common/Card";
 import { Chip } from "@/components/common/Chip";
 import { useAuthStore } from "@/lib/store/useAuthStore";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 export default function HomePage() {
-  const router = useRouter();
-  const { user, isAuthenticated, _hasHydrated } = useAuthStore();
+  const { user } = useAuthStore();
 
-  useEffect(() => {
-    if (_hasHydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [_hasHydrated, isAuthenticated, router]);
-
-  if (!_hasHydrated || !isAuthenticated) {
-    return <div className="flex-1 bg-white" />;
-  }
+  const rightAction = (
+    <div className="relative p-2 cursor-pointer">
+      <Bell className="w-[22px] h-[22px] text-grey-700" />
+      <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-[1.5px] border-white" />
+    </div>
+  );
 
   return (
-    <div className="flex flex-col h-full bg-white">
-      <TopBar
-        showLogo
-        rightAction={
-          <div className="relative p-2 cursor-pointer">
-            <Bell className="w-[22px] h-[22px] text-grey-700" />
-            <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-[1.5px] border-white" />
-          </div>
-        }
-      />
+    <AuthGuard showLogo rightAction={rightAction}>
+      <div className="flex flex-col h-full bg-white">
+        <TopBar showLogo rightAction={rightAction} />
 
-      <main className="flex-1 overflow-y-auto no-scrollbar">
-        <section className="px-5 py-6 bg-white">
-          <h1 className="text-2xl font-bold text-grey-900 leading-8 tracking-tight">
-            {user?.nickname}님,<br />
-            오늘 점심 같이 먹을래요?
-          </h1>
-          <div className="flex items-center gap-1 mt-2.5 text-[13px] font-medium text-grey-600">
-            <span>모집 중 <strong className="font-bold text-grey-900">3</strong></span>
-            <div className="w-0.5 h-0.5 rounded-full bg-grey-400 mx-1" />
-            <span>마감 임박 <strong className="font-bold text-grey-900">1</strong></span>
-          </div>
-        </section>
+        <main className="flex-1 overflow-y-auto no-scrollbar">
+          <section className="px-5 py-6 bg-white">
+            <h1 className="text-2xl font-bold text-grey-900 leading-8 tracking-tight">
+              {user?.nickname}님,<br />
+              오늘 점심 같이 먹을래요?
+            </h1>
+            <div className="flex items-center gap-1 mt-2.5 text-[13px] font-medium text-grey-600">
+              <span>모집 중 <strong className="font-bold text-grey-900">3</strong></span>
+              <div className="w-0.5 h-0.5 rounded-full bg-grey-400 mx-1" />
+              <span>마감 임박 <strong className="font-bold text-grey-900">1</strong></span>
+            </div>
+          </section>
 
-        <div className="h-2 bg-grey-100" />
+          <div className="h-2 bg-grey-100" />
 
-        <section className="px-5 py-3 flex gap-2 overflow-x-auto no-scrollbar bg-white sticky top-0 z-10 border-b border-grey-50">
-          <Chip active>전체</Chip>
-          <Chip>점심</Chip>
-          <Chip>저녁</Chip>
-          <Chip>학생회관</Chip>
-          <Chip>정문</Chip>
-          <Chip>한식</Chip>
-          <Chip>일식</Chip>
-        </section>
+          <section className="px-5 py-3 flex gap-2 overflow-x-auto no-scrollbar bg-white sticky top-0 z-10 border-b border-grey-50">
+            <Chip active>전체</Chip>
+            <Chip>점심</Chip>
+            <Chip>저녁</Chip>
+            <Chip>학생회관</Chip>
+            <Chip>정문</Chip>
+            <Chip>한식</Chip>
+            <Chip>일식</Chip>
+          </section>
 
-        <section className="flex-1 bg-grey-50 px-5 py-4 space-y-2.5 min-h-screen">
-          <Card
-            thumbnail="🍲"
-            category="한식"
-            status="urgent"
-            time="12:15"
-            title="부대찌개 + 공기밥"
-            location="학생회관 1층"
-            currentParticipants={3}
-            maxParticipants={4}
-            avatars={[]}
-          />
-          <Card
-            thumbnail="🥘"
-            category="한식"
-            status="active"
-            time="12:30"
-            title="김치찌개 + 공기밥"
-            location="정문 앞 한솥"
-            currentParticipants={1}
-            maxParticipants={3}
-            avatars={[]}
-          />
-          <Card
-            thumbnail="🍣"
-            category="일식"
-            status="active"
-            time="13:00"
-            title="스시로 런치세트"
-            location="정문 스시로"
-            currentParticipants={2}
-            maxParticipants={4}
-            avatars={[]}
-          />
-        </section>
-      </main>
+          <section className="flex-1 bg-grey-50 px-5 py-4 space-y-2.5 min-h-screen">
+            <Card
+              thumbnail="🍲"
+              category="한식"
+              status="urgent"
+              time="12:15"
+              title="부대찌개 + 공기밥"
+              location="학생회관 1층"
+              currentParticipants={3}
+              maxParticipants={4}
+              avatars={[]}
+            />
+            <Card
+              thumbnail="🥘"
+              category="한식"
+              status="active"
+              time="12:30"
+              title="김치찌개 + 공기밥"
+              location="정문 앞 한솥"
+              currentParticipants={1}
+              maxParticipants={3}
+              avatars={[]}
+            />
+            <Card
+              thumbnail="🍣"
+              category="일식"
+              status="active"
+              time="13:00"
+              title="스시로 런치세트"
+              location="정문 스시로"
+              currentParticipants={2}
+              maxParticipants={4}
+              avatars={[]}
+            />
+          </section>
+        </main>
 
-      <BottomNav />
-    </div>
+        <BottomNav />
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { TopBar } from "@/components/layout/TopBar";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
+
+  if (!_hasHydrated || !isAuthenticated) {
+    return <div className="flex-1 bg-white" />;
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <TopBar title="마이페이지" />
+      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+        <p className="text-[14px] text-grey-400">준비 중이에요</p>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { TopBar } from "@/components/layout/TopBar";
 import { BottomNav } from "@/components/layout/BottomNav";
-import { useAuthStore } from "@/lib/store/useAuthStore";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 export default function ProfilePage() {
-  const router = useRouter();
-  const { isAuthenticated, _hasHydrated } = useAuthStore();
-
-  useEffect(() => {
-    if (_hasHydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [_hasHydrated, isAuthenticated, router]);
-
-  if (!_hasHydrated || !isAuthenticated) {
-    return <div className="flex-1 bg-white" />;
-  }
-
   return (
-    <div className="flex flex-col h-full bg-white">
-      <TopBar title="마이페이지" />
-      <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
-        <p className="text-[14px] text-grey-400">준비 중이에요</p>
-      </main>
-      <BottomNav />
-    </div>
+    <AuthGuard title="마이페이지">
+      <div className="flex flex-col h-full bg-white">
+        <TopBar title="마이페이지" />
+        <main className="flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+          <p className="text-[14px] text-grey-400">준비 중이에요</p>
+        </main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/app/users/[...path]/route.ts
+++ b/src/app/users/[...path]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { proxyRequest } from "@/lib/api-proxy";
 
-export const GET = (req: NextRequest) => proxyRequest(req);
-export const POST = (req: NextRequest) => proxyRequest(req);
-export const PUT = (req: NextRequest) => proxyRequest(req);
-export const PATCH = (req: NextRequest) => proxyRequest(req);
-export const DELETE = (req: NextRequest) => proxyRequest(req);
+export const GET = async (req: NextRequest) => await proxyRequest(req);
+export const POST = async (req: NextRequest) => await proxyRequest(req);
+export const PUT = async (req: NextRequest) => await proxyRequest(req);
+export const PATCH = async (req: NextRequest) => await proxyRequest(req);
+export const DELETE = async (req: NextRequest) => await proxyRequest(req);

--- a/src/app/users/[...path]/route.ts
+++ b/src/app/users/[...path]/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { proxyRequest } from "@/lib/api-proxy";
+
+export const GET = (req: NextRequest) => proxyRequest(req);
+export const POST = (req: NextRequest) => proxyRequest(req);
+export const PUT = (req: NextRequest) => proxyRequest(req);
+export const PATCH = (req: NextRequest) => proxyRequest(req);
+export const DELETE = (req: NextRequest) => proxyRequest(req);

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/lib/store/useAuthStore";
+import { TopBar } from "../layout/TopBar";
+import { BottomNav } from "../layout/BottomNav";
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+  title?: string;
+  showLogo?: boolean;
+  rightAction?: React.ReactNode;
+}
+
+export function AuthGuard({ 
+  children, 
+  title, 
+  showLogo = false,
+  rightAction 
+}: AuthGuardProps) {
+  const router = useRouter();
+  const { isAuthenticated, _hasHydrated } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [_hasHydrated, isAuthenticated, router]);
+
+  // 하이드레이션 전이거나 인증되지 않은 경우 (리다이렉트 전) 골격 UI 렌더링
+  if (!_hasHydrated || !isAuthenticated) {
+    return (
+      <div className="flex flex-col h-full bg-white">
+        <TopBar 
+          title={title} 
+          showLogo={showLogo} 
+          rightAction={rightAction}
+        />
+        <div className="flex-1 bg-white" />
+        <BottomNav />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -13,14 +13,21 @@ interface AuthGuardProps {
   rightAction?: React.ReactNode;
 }
 
-export function AuthGuard({ 
-  children, 
-  title, 
+export function AuthGuard({
+  children,
+  title,
   showLogo = false,
-  rightAction 
+  rightAction
 }: AuthGuardProps) {
   const router = useRouter();
-  const { isAuthenticated, _hasHydrated } = useAuthStore();
+  const { isAuthenticated, _hasHydrated, initAuth } = useAuthStore();
+
+  useEffect(() => {
+    if (_hasHydrated) {
+      initAuth();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_hasHydrated]);
 
   useEffect(() => {
     if (_hasHydrated && !isAuthenticated) {
@@ -28,13 +35,12 @@ export function AuthGuard({
     }
   }, [_hasHydrated, isAuthenticated, router]);
 
-  // 하이드레이션 전이거나 인증되지 않은 경우 (리다이렉트 전) 골격 UI 렌더링
   if (!_hasHydrated || !isAuthenticated) {
     return (
       <div className="flex flex-col h-full bg-white">
-        <TopBar 
-          title={title} 
-          showLogo={showLogo} 
+        <TopBar
+          title={title}
+          showLogo={showLogo}
           rightAction={rightAction}
         />
         <div className="flex-1 bg-white" />

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -14,7 +14,6 @@ interface CardProps {
   maxParticipants: number;
   avatars?: string[];
   className?: string;
-  urgent?: boolean;
 }
 
 export function Card({
@@ -28,13 +27,12 @@ export function Card({
   maxParticipants,
   avatars = [],
   className,
-  urgent = false,
 }: CardProps) {
   return (
     <div
       className={cn(
         "bg-cream-50 border border-grey-200 rounded-2xl overflow-hidden cursor-pointer active:scale-[0.98] transition-transform",
-        urgent && "border-l-[3px] border-l-red-500",
+        status === "urgent" && "border-l-[3px] border-l-red-500",
         className
       )}
     >

--- a/src/lib/api-proxy.ts
+++ b/src/lib/api-proxy.ts
@@ -5,15 +5,35 @@ import { serverFetchRaw } from "./fetch";
 export async function proxyRequest(req: NextRequest): Promise<NextResponse> {
   const url = req.nextUrl.pathname + req.nextUrl.search;
   const token = req.headers.get("Authorization")?.replace(/^Bearer\s+/, "") ?? undefined;
-  const body = !["GET", "HEAD"].includes(req.method) ? await req.text() : undefined;
+  
+  let body: string | undefined;
+  if (!["GET", "HEAD"].includes(req.method)) {
+    try {
+      body = await req.text();
+    } catch (e) {
+      console.error("[Proxy] Error reading request body:", e);
+    }
+  }
+
+  console.log(`[Proxy] ${req.method} ${url} -> Proxying to API`);
 
   try {
-    const { status, data } = await serverFetchRaw(url, token, {
+    const fetchOptions: RequestInit = {
       method: req.method,
-      body,
-    });
+    };
+
+    if (body !== undefined) {
+      fetchOptions.body = body;
+    }
+
+    const { status, data } = await serverFetchRaw(url, token, fetchOptions);
+    console.log(`[Proxy] API responded with status ${status}`);
     return NextResponse.json(data, { status });
-  } catch {
-    return NextResponse.json({ message: "Upstream error" }, { status: 502 });
+  } catch (error) {
+    console.error("[Proxy] Critical Error:", error);
+    return NextResponse.json(
+      { message: "Internal Proxy Error", error: String(error) }, 
+      { status: 500 }
+    );
   }
 }

--- a/src/lib/api-proxy.ts
+++ b/src/lib/api-proxy.ts
@@ -1,0 +1,19 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { serverFetchRaw } from "./fetch";
+
+export async function proxyRequest(req: NextRequest): Promise<NextResponse> {
+  const url = req.nextUrl.pathname + req.nextUrl.search;
+  const token = req.headers.get("Authorization")?.replace(/^Bearer\s+/, "") ?? undefined;
+  const body = !["GET", "HEAD"].includes(req.method) ? await req.text() : undefined;
+
+  try {
+    const { status, data } = await serverFetchRaw(url, token, {
+      method: req.method,
+      body,
+    });
+    return NextResponse.json(data, { status });
+  } catch {
+    return NextResponse.json({ message: "Upstream error" }, { status: 502 });
+  }
+}

--- a/src/lib/api-proxy.ts
+++ b/src/lib/api-proxy.ts
@@ -1,11 +1,13 @@
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { serverFetchRaw } from "./fetch";
 
 export async function proxyRequest(req: NextRequest): Promise<NextResponse> {
   const url = req.nextUrl.pathname + req.nextUrl.search;
-  const token = req.headers.get("Authorization")?.replace(/^Bearer\s+/, "") ?? undefined;
-  
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth-token")?.value;
+
   let body: string | undefined;
   if (!["GET", "HEAD"].includes(req.method)) {
     try {
@@ -15,25 +17,18 @@ export async function proxyRequest(req: NextRequest): Promise<NextResponse> {
     }
   }
 
-  console.log(`[Proxy] ${req.method} ${url} -> Proxying to API`);
+  if (process.env.NODE_ENV === "development") {
+    console.log(`[Proxy] ${req.method} ${url}`);
+  }
 
   try {
-    const fetchOptions: RequestInit = {
-      method: req.method,
-    };
-
-    if (body !== undefined) {
-      fetchOptions.body = body;
-    }
+    const fetchOptions: RequestInit = { method: req.method };
+    if (body !== undefined) fetchOptions.body = body;
 
     const { status, data } = await serverFetchRaw(url, token, fetchOptions);
-    console.log(`[Proxy] API responded with status ${status}`);
     return NextResponse.json(data, { status });
   } catch (error) {
-    console.error("[Proxy] Critical Error:", error);
-    return NextResponse.json(
-      { message: "Internal Proxy Error", error: String(error) }, 
-      { status: 500 }
-    );
+    console.error("[Proxy] Error:", error);
+    return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+const BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/$/, "");
+
+function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return headers;
+}
+
+function buildAuthHeaders(token?: string): Record<string, string> {
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function serverFetch<T = unknown>(
+  path: string,
+  token?: string,
+  init?: RequestInit,
+): Promise<T> {
+  if (!BASE)
+    throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
+
+  const isFormData = init?.body instanceof FormData;
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      ...(!["GET", "HEAD"].includes((init?.method ?? "GET").toUpperCase()) &&
+      !isFormData
+        ? { "Content-Type": "application/json" }
+        : {}),
+      ...normalizeHeaders(init?.headers),
+      ...buildAuthHeaders(token),
+    },
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
+  return json as T;
+}
+
+export async function serverFetchRaw(
+  path: string,
+  token?: string,
+  init?: RequestInit,
+): Promise<{ status: number; data: unknown }> {
+  if (!BASE)
+    throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
+
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      ...(["GET", "HEAD"].includes((init?.method ?? "GET").toUpperCase())
+        ? {}
+        : { "Content-Type": "application/json" }),
+      ...normalizeHeaders(init?.headers),
+      ...buildAuthHeaders(token),
+    },
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return { status: res.status, data };
+}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-const BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/$/, "");
+const BASE = (process.env.API_BASE_URL ?? "").replace(/\/$/, "");
 
 function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
   if (!headers) return {};
@@ -20,7 +20,7 @@ export async function serverFetch<T = unknown>(
   init?: RequestInit,
 ): Promise<T> {
   if (!BASE)
-    throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
+    throw new Error("[serverFetch] API_BASE_URL is not configured");
 
   const method = (init?.method ?? "GET").toUpperCase();
   const isSafeMethod = ["GET", "HEAD"].includes(method);
@@ -55,13 +55,14 @@ export async function serverFetchRaw(
   init?: RequestInit,
 ): Promise<{ status: number; data: unknown }> {
   if (!BASE)
-    throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
+    throw new Error("[serverFetch] API_BASE_URL is not configured");
 
   const method = (init?.method ?? "GET").toUpperCase();
   const isSafeMethod = ["GET", "HEAD"].includes(method);
+  const isFormData = init?.body instanceof FormData;
 
   const headers: Record<string, string> = {
-    ...(!isSafeMethod ? { "Content-Type": "application/json" } : {}),
+    ...(!isSafeMethod && !isFormData ? { "Content-Type": "application/json" } : {}),
     ...normalizeHeaders(init?.headers),
     ...buildAuthHeaders(token),
   };
@@ -72,7 +73,6 @@ export async function serverFetchRaw(
     headers,
   };
 
-  // Ensure body is not present for GET/HEAD
   if (isSafeMethod) {
     delete fetchOptions.body;
   }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -22,18 +22,27 @@ export async function serverFetch<T = unknown>(
   if (!BASE)
     throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
 
+  const method = (init?.method ?? "GET").toUpperCase();
+  const isSafeMethod = ["GET", "HEAD"].includes(method);
   const isFormData = init?.body instanceof FormData;
-  const res = await fetch(`${BASE}${path}`, {
+
+  const headers: Record<string, string> = {
+    ...(!isSafeMethod && !isFormData ? { "Content-Type": "application/json" } : {}),
+    ...normalizeHeaders(init?.headers),
+    ...buildAuthHeaders(token),
+  };
+
+  const fetchOptions: RequestInit = {
     ...init,
-    headers: {
-      ...(!["GET", "HEAD"].includes((init?.method ?? "GET").toUpperCase()) &&
-      !isFormData
-        ? { "Content-Type": "application/json" }
-        : {}),
-      ...normalizeHeaders(init?.headers),
-      ...buildAuthHeaders(token),
-    },
-  });
+    method,
+    headers,
+  };
+
+  if (isSafeMethod) {
+    delete fetchOptions.body;
+  }
+
+  const res = await fetch(`${BASE}${path}`, fetchOptions);
 
   const json = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
@@ -48,16 +57,27 @@ export async function serverFetchRaw(
   if (!BASE)
     throw new Error("[serverFetch] NEXT_PUBLIC_API_BASE_URL is not configured");
 
-  const res = await fetch(`${BASE}${path}`, {
+  const method = (init?.method ?? "GET").toUpperCase();
+  const isSafeMethod = ["GET", "HEAD"].includes(method);
+
+  const headers: Record<string, string> = {
+    ...(!isSafeMethod ? { "Content-Type": "application/json" } : {}),
+    ...normalizeHeaders(init?.headers),
+    ...buildAuthHeaders(token),
+  };
+
+  const fetchOptions: RequestInit = {
     ...init,
-    headers: {
-      ...(["GET", "HEAD"].includes((init?.method ?? "GET").toUpperCase())
-        ? {}
-        : { "Content-Type": "application/json" }),
-      ...normalizeHeaders(init?.headers),
-      ...buildAuthHeaders(token),
-    },
-  });
+    method,
+    headers,
+  };
+
+  // Ensure body is not present for GET/HEAD
+  if (isSafeMethod) {
+    delete fetchOptions.body;
+  }
+
+  const res = await fetch(`${BASE}${path}`, fetchOptions);
 
   const data = await res.json().catch(() => ({}));
   return { status: res.status, data };

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -29,6 +29,6 @@ export const useAuthStore = create<AuthState>()(
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
       },
-    }
-  )
+    },
+  ),
 );

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { User } from "@/types/auth";
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  _hasHydrated: boolean;
+  setAuth: (user: User, token: string) => void;
+  logout: () => void;
+  setHasHydrated: (state: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      token: null,
+      isAuthenticated: false,
+      _hasHydrated: false,
+      setAuth: (user, token) => set({ user, token, isAuthenticated: true }),
+      logout: () => set({ user: null, token: null, isAuthenticated: false }),
+      setHasHydrated: (state) => set({ _hasHydrated: state }),
+    }),
+    {
+      name: "auth-storage",
+      storage: createJSONStorage(() => localStorage),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    }
+  )
+);

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -4,11 +4,10 @@ import { User } from "@/types/auth";
 
 interface AuthState {
   user: User | null;
-  token: string | null;
   isAuthenticated: boolean;
   _hasHydrated: boolean;
-  setAuth: (user: User, token: string) => void;
-  logout: () => void;
+  setAuth: (user: User) => void;
+  logout: () => Promise<void>;
   setHasHydrated: (state: boolean) => void;
 }
 
@@ -16,11 +15,16 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,
-      token: null,
       isAuthenticated: false,
       _hasHydrated: false,
-      setAuth: (user, token) => set({ user, token, isAuthenticated: true }),
-      logout: () => set({ user: null, token: null, isAuthenticated: false }),
+      setAuth: (user) => set({ user, isAuthenticated: true }),
+      logout: async () => {
+        try {
+          await fetch("/auth/logout", { method: "POST" });
+        } finally {
+          set({ user: null, isAuthenticated: false });
+        }
+      },
       setHasHydrated: (state) => set({ _hasHydrated: state }),
     }),
     {
@@ -28,7 +32,6 @@ export const useAuthStore = create<AuthState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         user: state.user,
-        token: state.token,
         isAuthenticated: state.isAuthenticated,
       }),
       onRehydrateStorage: () => (state) => {

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -26,6 +26,11 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "auth-storage",
       storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        user: state.user,
+        token: state.token,
+        isAuthenticated: state.isAuthenticated,
+      }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
       },

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { User } from "@/types/auth";
+import { authService } from "@/services/auth.service";
 
 interface AuthState {
   user: User | null;
@@ -9,11 +10,12 @@ interface AuthState {
   setAuth: (user: User) => void;
   logout: () => Promise<void>;
   setHasHydrated: (state: boolean) => void;
+  initAuth: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       user: null,
       isAuthenticated: false,
       _hasHydrated: false,
@@ -26,6 +28,22 @@ export const useAuthStore = create<AuthState>()(
         }
       },
       setHasHydrated: (state) => set({ _hasHydrated: state }),
+      initAuth: async () => {
+        if (!get().isAuthenticated) return;
+        try {
+          const user = await authService.getMe();
+          set({ user, isAuthenticated: true });
+        } catch {
+          // 쿠키 만료 → refresh 시도
+          try {
+            await authService.refresh();
+            const user = await authService.getMe();
+            set({ user, isAuthenticated: true });
+          } catch {
+            set({ user: null, isAuthenticated: false });
+          }
+        }
+      },
     }),
     {
       name: "auth-storage",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,6 @@
-export function cn(...inputs: (string | undefined | null | boolean)[]) {
-  return inputs.filter(Boolean).join(' ');
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,5 @@
 import { RegisterPayload, AuthResponse, User } from "@/types/auth";
+import { useAuthStore } from "@/lib/store/useAuthStore";
 
 const BASE = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? "";
 
@@ -16,7 +17,10 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 
 async function get<T>(path: string): Promise<T> {
   if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured");
-  const res = await fetch(`${BASE}${path}`);
+  const token = useAuthStore.getState().token;
+  const res = await fetch(`${BASE}${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
   const json = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
   return json as T;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,43 @@
+import { RegisterPayload, AuthResponse, User } from "@/types/auth";
+
+const BASE = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? "";
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured");
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
+  return json as T;
+}
+
+async function get<T>(path: string): Promise<T> {
+  if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured");
+  const res = await fetch(`${BASE}${path}`);
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
+  return json as T;
+}
+
+export const authService = {
+  login: (email: string, password: string) =>
+    post<AuthResponse>("/api/auth/login", { email, password }),
+
+  sendCode: (email: string) =>
+    post<{ message: string }>("/api/auth/send-code", { email }),
+
+  verifyCode: (email: string, code: string) =>
+    post<{ verified: boolean }>("/api/auth/verify-code", { email, code }),
+
+  checkNickname: (nickname: string) =>
+    post<{ available: boolean }>("/api/auth/check-nickname", { nickname }),
+
+  register: (data: RegisterPayload) =>
+    post<AuthResponse>("/api/auth/register", data),
+
+  getMe: () =>
+    get<User>("/api/members/me"),
+};

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,11 +1,8 @@
 import { RegisterPayload, AuthResponse, User } from "@/types/auth";
 import { useAuthStore } from "@/lib/store/useAuthStore";
 
-const BASE = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? "";
-
 async function post<T>(path: string, body: unknown): Promise<T> {
-  if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured");
-  const res = await fetch(`${BASE}${path}`, {
+  const res = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -16,9 +13,8 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function get<T>(path: string): Promise<T> {
-  if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured");
   const token = useAuthStore.getState().token;
-  const res = await fetch(`${BASE}${path}`, {
+  const res = await fetch(path, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   const json = await res.json().catch(() => ({}));
@@ -28,20 +24,20 @@ async function get<T>(path: string): Promise<T> {
 
 export const authService = {
   login: (email: string, password: string) =>
-    post<AuthResponse>("/api/auth/login", { email, password }),
+    post<AuthResponse>("/auth/login", { email, password }),
 
   sendCode: (email: string) =>
-    post<{ message: string }>("/api/auth/send-code", { email }),
+    post<{ message: string }>("/auth/send-code", { email }),
 
   verifyCode: (email: string, code: string) =>
-    post<{ verified: boolean }>("/api/auth/verify-code", { email, code }),
+    post<{ verified: boolean }>("/auth/verify-code", { email, code }),
 
   checkNickname: (nickname: string) =>
-    post<{ available: boolean }>("/api/auth/check-nickname", { nickname }),
+    post<{ available: boolean }>("/auth/check-nickname", { nickname }),
 
   register: (data: RegisterPayload) =>
-    post<AuthResponse>("/api/auth/register", data),
+    post<AuthResponse>("/auth/register", data),
 
   getMe: () =>
-    get<User>("/api/members/me"),
+    get<User>("/users/me"),
 };

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,4 @@
 import { RegisterPayload, AuthResponse, User } from "@/types/auth";
-import { useAuthStore } from "@/lib/store/useAuthStore";
 
 async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(path, {
@@ -13,10 +12,7 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function get<T>(path: string): Promise<T> {
-  const token = useAuthStore.getState().token;
-  const res = await fetch(path, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
+  const res = await fetch(path);
   const json = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error((json as { message?: string }).message ?? `HTTP ${res.status}`);
   return json as T;
@@ -24,7 +20,7 @@ async function get<T>(path: string): Promise<T> {
 
 export const authService = {
   login: (email: string, password: string) =>
-    post<AuthResponse>("/auth/login", { email, password }),
+    post<Omit<AuthResponse, "token">>("/auth/login", { email, password }),
 
   sendCode: (email: string) =>
     post<{ message: string }>("/auth/send-code", { email }),
@@ -36,7 +32,7 @@ export const authService = {
     post<{ available: boolean }>("/auth/check-nickname", { nickname }),
 
   register: (data: RegisterPayload) =>
-    post<AuthResponse>("/auth/register", data),
+    post<Omit<AuthResponse, "token">>("/auth/register", data),
 
   getMe: () =>
     get<User>("/users/me"),

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -20,7 +20,7 @@ async function get<T>(path: string): Promise<T> {
 
 export const authService = {
   login: (email: string, password: string) =>
-    post<Omit<AuthResponse, "token">>("/auth/login", { email, password }),
+    post<Omit<AuthResponse, "access_token" | "refresh_token">>("/auth/login", { email, password }),
 
   sendCode: (email: string) =>
     post<{ message: string }>("/auth/send-code", { email }),
@@ -32,7 +32,10 @@ export const authService = {
     post<{ available: boolean }>("/auth/check-nickname", { nickname }),
 
   register: (data: RegisterPayload) =>
-    post<Omit<AuthResponse, "token">>("/auth/register", data),
+    post<Omit<AuthResponse, "access_token" | "refresh_token">>("/auth/register", data),
+
+  refresh: () =>
+    post<{ message: string }>("/auth/refresh", {}),
 
   getMe: () =>
     get<User>("/users/me"),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,7 +42,111 @@ body {
 }
 
 /* =============================================
-   UTILITY CLASSES (From Design v3)
+   TOP BAR
+============================================= */
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 16px 4px 12px;
+  height: 52px;
+  background: var(--white);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 5;
+  border-bottom: 1px solid var(--grey-100);
+}
+.top-bar .bar-logo-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.top-bar .logo-pill {
+  width: 30px; height: 30px;
+  background: var(--primary-500);
+  border-radius: 9px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.top-bar .logo-name {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--grey-900);
+  letter-spacing: -0.4px;
+}
+.top-bar .bar-btn {
+  width: 44px; height: 44px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 12px; cursor: pointer; flex-shrink: 0;
+}
+.top-bar .bar-title {
+  font-size: 17px; font-weight: 600; color: var(--grey-900);
+  letter-spacing: -0.3px; flex: 1; text-align: center;
+}
+.top-bar .bar-action {
+  font-size: 14px; font-weight: 500; color: var(--grey-600);
+  padding: 6px 10px; cursor: pointer;
+}
+
+/* =============================================
+   BOTTOM NAV
+============================================= */
+.bottom-nav {
+  background: var(--white);
+  border-top: 1px solid var(--grey-200);
+  display: flex;
+  align-items: flex-end;
+  padding: 8px 0 22px;
+  flex-shrink: 0;
+}
+.nav-item {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; gap: 3px; padding-top: 4px; cursor: pointer;
+}
+.nav-item i, .nav-item svg { color: var(--grey-400); }
+.nav-item.active i, .nav-item.active svg { color: var(--primary-600); }
+.nav-label { font-size: 10px; font-weight: 600; color: var(--grey-400); letter-spacing: 0.2px; }
+.nav-item.active .nav-label { color: var(--primary-600); }
+.nav-fab-wrap {
+  flex: 1; display: flex; justify-content: center; align-items: flex-end;
+  position: relative; top: -14px;
+}
+.nav-fab {
+  width: 52px; height: 52px; border-radius: 9999px;
+  background: var(--primary-500); box-shadow: var(--shadow-glow);
+  display: flex; align-items: center; justify-content: center;
+}
+.nav-fab i, .nav-fab svg { color: var(--grey-900); }
+
+/* =============================================
+   INPUT — borderless, grey-100 fill, r=14px
+============================================= */
+.input-label-group { margin-bottom: 20px; }
+.input-caption {
+  font-size: 11px; font-weight: 700; color: var(--grey-500);
+  letter-spacing: 1.2px; text-transform: uppercase;
+  margin-bottom: 6px; display: block;
+}
+.input-row {
+  position: relative; display: flex; align-items: center;
+}
+.input-field {
+  width: 100%; height: 52px; padding: 0 16px;
+  background: var(--grey-100); border: none; border-radius: 14px;
+  font-family: var(--font); font-size: 16px; font-weight: 400;
+  color: var(--grey-900); outline: none; transition: background 0.15s;
+}
+.input-field:focus { background: var(--grey-200); }
+.input-field::placeholder { color: var(--grey-400); }
+
+.input-timer {
+  position: absolute; right: 16px;
+  font-size: 14px; font-weight: 700; color: var(--red-500);
+  letter-spacing: -0.3px;
+}
+
+/* =============================================
+   UTILITY CLASSES
 ============================================= */
 
 /* Badges */
@@ -84,10 +188,16 @@ body {
   transition: background 0.15s;
 }
 .btn-primary:hover { background: var(--primary-400); }
+
+/* Combined disabled states to avoid flash/blink issues */
+.btn-primary:disabled, 
 .btn-primary.disabled {
-  background: var(--grey-200); color: var(--grey-500);
-  cursor: not-allowed; box-shadow: none;
+  background: var(--grey-200) !important; 
+  color: var(--grey-500) !important;
+  cursor: not-allowed; 
+  box-shadow: none !important;
 }
+
 .btn-weak-primary {
   display: block; width: 100%; height: 54px;
   background: var(--primary-100); color: var(--primary-700);
@@ -95,12 +205,21 @@ body {
   border: none; border-radius: var(--r-full); cursor: pointer;
   letter-spacing: -0.2px;
 }
+.btn-weak-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .btn-weak-danger {
   display: block; width: 100%; height: 54px;
   background: var(--red-50); color: var(--red-500);
   font-family: var(--font); font-size: 17px; font-weight: 600;
   border: none; border-radius: var(--r-full); cursor: pointer;
   letter-spacing: -0.2px;
+}
+.btn-weak-danger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* Animations */

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,26 @@
+export interface User {
+  id: string;
+  email: string;
+  nickname: string;
+  avatar: string | null;
+  department?: string;
+  admissionYear?: string;
+  bio?: string;
+  category?: string[];
+}
+
+export interface AuthResponse {
+  message: string;
+  user: User;
+  token: string;
+}
+
+export interface RegisterPayload {
+  email: string;
+  password: string;
+  nickname: string;
+  department: string;
+  admission_year: string;
+  bio?: string;
+  category?: string[];
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -20,7 +20,7 @@ export interface RegisterPayload {
   password: string;
   nickname: string;
   department: string;
-  admission_year: string;
+  admissionYear: string;
   bio?: string;
   category?: string[];
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -4,7 +4,7 @@ export interface User {
   nickname: string;
   avatar: string | null;
   department?: string;
-  admissionYear?: string;
+  admission_year?: string;
   bio?: string;
   category?: string[];
 }
@@ -12,7 +12,8 @@ export interface User {
 export interface AuthResponse {
   message: string;
   user: User;
-  token: string;
+  access_token: string;
+  refresh_token?: string;
 }
 
 export interface RegisterPayload {
@@ -20,7 +21,7 @@ export interface RegisterPayload {
   password: string;
   nickname: string;
   department: string;
-  admissionYear: string;
+  admission_year: string;
   bio?: string;
   category?: string[];
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #3 

## 📝작업 내용

Next.js 앱의 인증 흐름 전체를 구현했습니다. MSW 기반 개발 목업 서버 구성부터 로그인/회원가입 UI, 인증 상태 관리, 보안을 위한 httpOnly 쿠키 전환, 백엔드 API 스펙 정합까지 포함합니다.

---

## 🏗️ 주요 작업

### 1. 인프라 / 기반 설정

- **`serverFetch` 래퍼** (`src/lib/fetch.ts`)
  - `server-only` 가드 적용으로 클라이언트 번들 노출 차단
  - `serverFetch` / `serverFetchRaw` 두 가지 인터페이스 제공
  - FormData 감지 시 `Content-Type` 헤더 자동 생략

- **API 프록시** (`src/lib/api-proxy.ts`)
  - Next.js Route Handler에서 `auth-token` 쿠키를 읽어 `Authorization: Bearer`로 백엔드에 포워딩
  - `API_BASE_URL` 서버 전용 환경 변수로 외부 노출 차단

- **MSW 개발 서버** (`mocks/`)
  - `tsx mocks/dev-server.ts` — `127.0.0.1:9090` Express 기반 목업 서버
  - `pnpm dev:mock` 으로 Next.js + 목업 서버 동시 실행

### 2. 인증 타입 및 서비스 레이어

- **타입 정의** (`src/types/auth.ts`)
  - `User`, `AuthResponse`, `RegisterPayload` 인터페이스
  - 스펙 통일: `admissionYear` → `admission_year`, `token` → `access_token` / `refresh_token`

- **인증 서비스** (`src/services/auth.service.ts`)
  - `login`, `register`, `sendCode`, `verifyCode`, `checkNickname`, `refresh`, `getMe`
  - 모든 경로는 Next.js Route Handler를 경유하는 상대경로 (`/auth/...`)

### 3. 인증 상태 관리

- **Zustand 스토어** (`src/lib/store/useAuthStore.ts`)
  - `user`, `isAuthenticated`, `_hasHydrated` 상태
  - `localStorage` persist (민감 토큰 제외, 유저 정보만 저장)
  - **`initAuth`**: 앱 마운트 시 `getMe` 호출 → 실패 시 `refresh` → 재시도 → 최종 실패 시 자동 로그아웃

- **AuthGuard** (`src/components/auth/AuthGuard.tsx`)
  - SSR/CSR 하이드레이션 안전 처리 (`_hasHydrated` 플래그)
  - 비인증 사용자 → `/login` 리디렉션
  - 마운트 시 `initAuth` 호출로 토큰 만료 자동 처리

### 4. Next.js Route Handlers (인증 전용 API)

httpOnly 쿠키 보안을 위해 클라이언트가 직접 백엔드를 호출하지 않고 Next.js Route Handler를 경유합니다.

| 경로 | 역할 |
|---|---|
| `POST /auth/login` | 백엔드 로그인 → `auth-token`(7d) + `refresh-token`(30d) 쿠키 설정 |
| `POST /auth/register` | 백엔드 회원가입 → `auth-token`(7d) 쿠키 설정 (refresh 미발급) |
| `POST /auth/refresh` | `refresh-token` 쿠키 읽어 백엔드 갱신 요청 → 새 `auth-token` 설정 |
| `POST /auth/logout` | `refresh-token` body 전송 + `Authorization` 헤더로 백엔드 로그아웃 → 두 쿠키 삭제 |

### 5. UI 페이지

- **로그인 페이지** (`src/app/(auth)/login/page.tsx`)
  - react-hook-form 기반
  - 비밀번호 유효성: 영문 + 숫자 + 특수문자(`@$!%*#?&`) 포함 8자 이상
  - `@skhu.ac.kr` 이메일 자동 suffix

- **회원가입 페이지** (`src/app/(auth)/register/page.tsx`)
  - 2단계 폼 (이메일 인증 → 프로필 입력)
  - 이메일 인증코드 발송/확인
  - 닉네임 중복 체크 (스펙: 200 + `{ available }`)
  - 완료 시 자동 로그인

### 6. MSW 목업

- **핸들러** (`mocks/handlers/member.ts`)
  - `makeTokens()`: access_token + refresh_token 세션 분리 발급
  - login/register/refresh/logout/getMe 전 엔드포인트 구현
  - logout: Authorization 헤더 방식 → `refresh_token` body 방식으로 변경
  - register 응답에서 `refresh_token` 제거 (스펙 반영)

- **더미 데이터** (`mocks/data/members.json`, `mocks/factories/member.factory.ts`)
  - 필드명 `admission_year` 통일
  - faker.js 기반 랜덤 멤버 10명 자동 생성

---

## 🔒 보안 개선 사항

| 항목 | 이전 | 이후 |
|---|---|---|
| 토큰 저장 위치 | `localStorage` (XSS 취약) | `httpOnly` 쿠키 (JS 접근 불가) |
| 토큰 구성 | access_token 단일 | access_token(7d) + refresh_token(30d) 분리 |
| 토큰 갱신 | 없음 | 만료 시 `initAuth`가 자동 refresh |
| 클라이언트 상태 | 토큰 직접 저장 | 유저 정보만 저장, 토큰은 쿠키에만 존재 |
| API_BASE_URL | 클라이언트 노출 가능 | `server-only` + 서버 전용 env var |

---

## 📁 주요 파일 목록

```
src/
├── types/auth.ts                     # 인증 타입 정의
├── services/auth.service.ts          # 인증 API 서비스
├── lib/
│   ├── fetch.ts                      # server-only fetch 래퍼
│   ├── api-proxy.ts                  # 쿠키 → Authorization 포워딩
│   └── store/useAuthStore.ts         # Zustand 인증 스토어
├── components/auth/AuthGuard.tsx     # 인증 보호 컴포넌트
└── app/
    ├── auth/
    │   ├── login/route.ts            # 로그인 Route Handler
    │   ├── register/route.ts         # 회원가입 Route Handler
    │   ├── refresh/route.ts          # 토큰 갱신 Route Handler
    │   └── logout/route.ts           # 로그아웃 Route Handler
    └── (auth)/
        ├── login/page.tsx            # 로그인 UI
        └── register/page.tsx         # 회원가입 UI

mocks/
├── dev-server.ts                     # Express 목업 서버
├── handlers/member.ts                # 인증 MSW 핸들러
├── factories/member.factory.ts       # 더미 유저 생성
└── data/members.json                 # 시드 유저 데이터
```

---

## ✅ 백엔드 API 스펙 대응표

| 엔드포인트 | 스펙 | 구현 |
|---|---|---|
| `POST /auth/login` | access_token + refresh_token | ✅ |
| `POST /auth/send-code` | 이메일 인증코드 발송 | ✅ |
| `POST /auth/verify-code` | `{ verified: boolean }` | ✅ |
| `POST /auth/check-nickname` | `{ available: boolean }` (항상 200) | ✅ |
| `POST /auth/register` | access_token만 반환 | ✅ |
| `POST /auth/refresh` | refresh_token → 새 access_token | ✅ |
| `POST /auth/logout` 🔒 | refresh_token body + Authorization | ✅ |
| `GET /users/me` 🔒 | 현재 유저 정보 | ✅ |


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
